### PR TITLE
fix: handle missing cases in VerificationError switch statement

### DIFF
--- a/ios/DiditSdkBridge.swift
+++ b/ios/DiditSdkBridge.swift
@@ -202,6 +202,8 @@ public class DiditSdkBridge: NSObject {
         switch error {
         case .sessionExpired:
             return "sessionExpired"
+        case .retryBlocked:
+            return "retryBlocked"
         case .networkError:
             return "networkError"
         case .cameraAccessDenied:


### PR DESCRIPTION
## What
Add missing cases to the `mapErrorType(_:)` switch statement to satisfy Swift's exhaustive switch requirement on `VerificationError`.

## Why
The switch was not exhaustive — newly added cases in `VerificationError` were not handled, causing a compile-time error (`Switch must be exhaustive`).

## Changes
- Added missing `case` entries in `mapErrorType(_:)` to cover all `VerificationError` cases