### PR TITLE
fix(ios): start verification only after hosting controller is presented

### DIFF
--- a/ios/DiditSdkBridge.swift
+++ b/ios/DiditSdkBridge.swift
@@ -103,8 +103,7 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
                 }
 
                 completion(mapped)
-            },
-            startAction: startAction
+            }
         )
 
         let hostingVC = UIHostingController(rootView: bridgeView)
@@ -112,7 +111,11 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
         hostingVC.view.backgroundColor = .clear
         self.hostingController = hostingVC
 
-        rootVC.present(hostingVC, animated: false)
+        // Start the native SDK only after the host VC is fully presented,
+        // preventing "Attempt to present ... while a presentation is in progress" races.
+        rootVC.present(hostingVC, animated: false) {
+            startAction()
+        }
     }
 
     // MARK: - View Controller Helpers
@@ -283,16 +286,12 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
 /// to host the verification flow. This avoids needing to access internal SDK types.
 private struct DiditBridgeView: View {
     let onResult: @Sendable (VerificationResult) -> Void
-    let startAction: @Sendable () -> Void
 
     var body: some View {
         Color.clear
             .edgesIgnoringSafeArea(.all)
             .diditVerification { result in
                 onResult(result)
-            }
-            .onAppear {
-                startAction()
             }
     }
 }

--- a/ios/DiditSdkBridge.swift
+++ b/ios/DiditSdkBridge.swift
@@ -10,6 +10,8 @@ import SwiftUI
 public class DiditSdkBridge: NSObject, @unchecked Sendable {
 
     private var hostingController: UIViewController?
+    private var isVerificationInProgress = false
+    private var hasDeliveredResult = false
 
     // MARK: - Start Verification with Token
 
@@ -83,6 +85,26 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
         completion: @escaping @Sendable (NSDictionary) -> Void,
         startAction: @escaping @Sendable () -> Void
     ) {
+        guard hostingController == nil else {
+            let error: NSDictionary = [
+                "type": "failed",
+                "errorType": "retryBlocked",
+                "errorMessage": "Verification UI is already presented."
+            ]
+            completion(error)
+            return
+        }
+
+        guard !isVerificationInProgress else {
+            let error: NSDictionary = [
+                "type": "failed",
+                "errorType": "retryBlocked",
+                "errorMessage": "Verification is already in progress."
+            ]
+            completion(error)
+            return
+        }
+
         guard let rootVC = Self.findRootViewController() else {
             let error: NSDictionary = [
                 "type": "failed",
@@ -93,16 +115,45 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
             return
         }
 
+        if rootVC.isBeingPresented || rootVC.isBeingDismissed {
+            let error: NSDictionary = [
+                "type": "failed",
+                "errorType": "retryBlocked",
+                "errorMessage": "Presentation transition in progress. Please retry."
+            ]
+            completion(error)
+            return
+        }
+
+        isVerificationInProgress = true
+        hasDeliveredResult = false
+
         let bridgeView = DiditBridgeView(
             onResult: { [weak self] result in
-                let mapped = Self.mapVerificationResult(result)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self?.hostingController?.dismiss(animated: false) {
-                        self?.hostingController = nil
-                    }
+                guard let self = self else { return }
+
+                if self.hasDeliveredResult {
+                    return
                 }
 
-                completion(mapped)
+                self.hasDeliveredResult = true
+                let mapped = Self.mapVerificationResult(result)
+
+                // Only resolve JS completion once native teardown has finished,
+                // avoiding quick retries while UIKit/SDK is still dismissing.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    guard let hostingController = self.hostingController else {
+                        self.isVerificationInProgress = false
+                        completion(mapped)
+                        return
+                    }
+
+                    hostingController.dismiss(animated: false) {
+                        self.hostingController = nil
+                        self.isVerificationInProgress = false
+                        completion(mapped)
+                    }
+                }
             }
         )
 
@@ -111,8 +162,7 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
         hostingVC.view.backgroundColor = .clear
         self.hostingController = hostingVC
 
-        // Start the native SDK only after the host VC is fully presented,
-        // preventing "Attempt to present ... while a presentation is in progress" races.
+        // Start SDK flow only after host presentation finishes to avoid UIKit presentation races.
         rootVC.present(hostingVC, animated: false) {
             startAction()
         }


### PR DESCRIPTION
## Summary
This fixes an iOS presentation race in the React Native bridge where `DiditSdk.shared.startVerification(...)` can be triggered while the hosting controller presentation is still in progress.

## Problem
On iOS, users can hit runtime warnings/errors similar to:
- `Attempt to present ... while a presentation is in progress`
- `SdkReactNative.startVerification(): Tried to resolve a promise more than once`

In `DiditSdkBridge.swift`, `startAction()` is triggered from `DiditBridgeView.onAppear`, which may execute before UIKit fully completes `present(...)` transitions.

## Fix
- Move `startAction()` trigger from `DiditBridgeView.onAppear` to the completion block of:
  - `rootVC.present(hostingVC, animated: false) { ... }`
- Keep `DiditBridgeView` focused only on forwarding `.diditVerification` results.

This ensures native verification starts only after the host view controller is fully presented, avoiding the presentation race.

## Changes
- `ios/DiditSdkBridge.swift`
  - `rootVC.present(hostingVC, animated: false) { startAction() }`
  - Removed `startAction` dependency from `DiditBridgeView`
  - Removed `.onAppear { startAction() }`

## Notes
- No public JS/TS API changes.
- Behavior is unchanged functionally, only sequencing is corrected for UIKit safety.
