### PR TITLE
fix(ios): leaked hosting controller duplicates verification UI and crashes on second startVerification (New Architecture)

### DIFF
--- a/ios/DiditSdkBridge.swift
+++ b/ios/DiditSdkBridge.swift
@@ -11,6 +11,11 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
 
     private var hostingController: UIViewController?
 
+    /// Monotonic stamp for each presentation. Delayed teardown blocks capture
+    /// the stamp of their own run, so a block left over from a previous run
+    /// can never dismiss the host of a newer one.
+    private var presentationGeneration = 0
+
     // MARK: - Start Verification with Token
 
     /// Start verification using an existing session token.
@@ -83,6 +88,21 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
         completion: @escaping @Sendable (NSDictionary) -> Void,
         startAction: @escaping @Sendable () -> Void
     ) {
+        // A previous run can leave the transparent hosting controller behind:
+        // the delayed dismiss below may catch the SDK's cover mid-animation
+        // and dismiss that instead of the host. A stale host keeps observing
+        // DiditSdk.shared, so the next start would present the verification
+        // UI twice and re-fire the old completion (double-resolving the RN
+        // promise, which crashes under the New Architecture). Remove any
+        // leftover host before presenting a new one.
+        if let stale = self.hostingController {
+            (stale.presentingViewController ?? stale).dismiss(animated: false)
+            self.hostingController = nil
+        }
+
+        presentationGeneration += 1
+        let generation = presentationGeneration
+
         guard let rootVC = Self.findRootViewController() else {
             let error: NSDictionary = [
                 "type": "failed",
@@ -97,8 +117,19 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
             onResult: { [weak self] result in
                 let mapped = Self.mapVerificationResult(result)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self?.hostingController?.dismiss(animated: false) {
-                        self?.hostingController = nil
+                    // The generation check keeps this block scoped to its own
+                    // run: if a new verification started during the delay,
+                    // `hostingController` already points at the new host and
+                    // must not be torn down here.
+                    guard let self = self,
+                          self.presentationGeneration == generation,
+                          let host = self.hostingController else { return }
+                    // Dismiss from the presenter so the host itself is removed
+                    // even if the SDK's cover is still attached to it. Calling
+                    // dismiss on the host while it still has a presented child
+                    // dismisses the child instead, leaking the host.
+                    (host.presentingViewController ?? host).dismiss(animated: false) {
+                        self.hostingController = nil
                     }
                 }
 
@@ -126,9 +157,11 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
             return nil
         }
 
-        // Walk the presentation chain to find the topmost presented controller
+        // Walk the presentation chain to find the topmost presented controller.
+        // Skip controllers that are on their way out, so the verification UI is
+        // never presented from a host that is about to leave the hierarchy.
         var topVC = rootVC
-        while let presented = topVC.presentedViewController {
+        while let presented = topVC.presentedViewController, !presented.isBeingDismissed {
             topVC = presented
         }
         return topVC
@@ -285,10 +318,16 @@ private struct DiditBridgeView: View {
     let onResult: @Sendable (VerificationResult) -> Void
     let startAction: @Sendable () -> Void
 
+    // One-shot guard: a host that lingers through a later run would otherwise
+    // re-deliver a result for a promise that has already been settled.
+    @State private var didFinish = false
+
     var body: some View {
         Color.clear
             .edgesIgnoringSafeArea(.all)
             .diditVerification { result in
+                guard !didFinish else { return }
+                didFinish = true
                 onResult(result)
             }
             .onAppear {


### PR DESCRIPTION
## Summary

Fixes an iOS teardown bug in the RN bridge where the transparent `UIHostingController` can leak after a verification run, causing the **verification UI to be presented twice** on the next `startVerification()` call and **crashing New Architecture apps** when the flow is closed.

## Problem

In `presentVerification` (`ios/DiditSdkBridge.swift`), the result handler removes the transparent host with a delayed dismiss:

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
    self?.hostingController?.dismiss(animated: false) { ... }
}
```

If the SDK's full-screen cover is still animating out when this fires, `dismiss()` is delivered to the **presented cover instead of the host** (UIKit semantics: dismissing a VC that has a presented child dismisses the child). The invisible host then stays in the view hierarchy forever.

Because the leaked host keeps observing `DiditSdk.shared` through the `.diditVerification` modifier, the next `startVerification()` call:

1. Presents the verification UI **twice** — once per live observer (users see two stacked Didit screens).
2. On close, **both** `onComplete` handlers fire. The stale one re-invokes the completion of a previous call, double-resolving the RN promise:

```
SdkReactNative.startVerification(): Tried to resolve a promise more than once
```

On the old architecture this logs a warning; **on the New Architecture it crashes the app**.

Reproduction: open the verification flow, cancel it, open it again in the same app session (whether it reproduces depends on the cover's dismiss animation overlapping the 0.3 s delay). We hit this consistently in production-like testing on RN 0.81 + New Architecture (Expo SDK 54), SDK 4.0.4.

## Fix

- Remove any stale hosting controller before presenting a new one.
- Dismiss via `presentingViewController` so the host itself is removed even when the SDK cover is still attached to it.
- Stamp each presentation with a generation counter, so a delayed teardown block left over from a previous run can never dismiss the host of a verification that started during its 0.3 s window.
- Skip controllers that are `isBeingDismissed` when walking the presentation chain, so the new host is never presented from a controller that is about to leave the hierarchy.
- Make result delivery one-shot in `DiditBridgeView`, so a lingering view can never re-deliver a result for an already-settled promise.

No public JS/TS API changes.

## Related

- #16 reported another symptom of the same root cause (host not released → frozen touches).
- #21 fixes a separate presentation race on start (`startAction` fired from `onAppear` mid-transition). This PR intentionally does not touch that code path to avoid conflicts — both fixes are complementary, and we run both patched in our app with the full open → cancel → reopen → close cycle now working cleanly.

## Verification

Patched 4.0.4 with this change in our app (`pnpm patch`): before, second invocation showed a duplicated verification UI and crashed on close; after, repeated open/cancel/reopen cycles resolve exactly once per call with no leak and no crash.
