### PR TITLE
feat: add submitTransaction and getTransaction bridged to the native transaction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Returns: `Promise<VerificationResult>`
 
 ### `submitTransaction(transactionToken, transaction, options?)`
 
-Submit a transaction directly from the device. Requires a transaction SDK token minted by your backend via `POST /v3/transactions/sdk-token/`. Device intelligence is attached automatically. `autoLaunchAction` (default `true`) auto-launches only a `wallet_ownership` action natively, invoking `options.onTransactionUpdated` once it completes; a `verification_session` action is never auto-launched and is always returned on `result.actionRequired` for your app to launch with its own Didit verification integration.
+Submit a transaction directly from the device. Requires a transaction SDK token minted by your backend via `POST /v3/transactions/sdk-token/`. Device intelligence is attached automatically. `autoLaunchAction` (default `true`) auto-launches only a `wallet_ownership` action natively, invoking `options.onTransactionUpdated` once it completes; a `verification_session` action is never auto-launched and is always returned on `result.actionRequired` for your app to launch with its own Didit verification integration. Full guide: [SDK Transaction Submission](https://docs.didit.me/transaction-monitoring/sdk-transaction-submission).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Returns: `Promise<VerificationResult>`
 
 ### `submitTransaction(transactionToken, transaction, options?)`
 
-Submit a transaction directly from the device. Requires a transaction SDK token minted by your backend via `POST /v3/transactions/sdk-token/`. Device intelligence is attached automatically. If the response contains a required user action (verification session or wallet-ownership widget), the SDK auto-launches it natively and invokes `options.onTransactionUpdated` with the refreshed transaction once the action completes.
+Submit a transaction directly from the device. Requires a transaction SDK token minted by your backend via `POST /v3/transactions/sdk-token/`. Device intelligence is attached automatically. `autoLaunchAction` (default `true`) auto-launches only a `wallet_ownership` action natively, invoking `options.onTransactionUpdated` once it completes; a `verification_session` action is never auto-launched and is always returned on `result.actionRequired` for your app to launch with its own Didit verification integration.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -680,6 +680,20 @@ try {
   if (error instanceof DiditTransactionError) {
     console.log(error.code, error.fieldErrors);
   }
+}
+```
+
+A `verification_session` action is returned, not auto-launched - launch it yourself with `startVerification`:
+
+```tsx
+import { submitTransaction, startVerification } from '@didit-protocol/sdk-react-native';
+
+const result = await submitTransaction(sdkToken, transaction);
+
+if (result.actionRequired?.type === 'verification_session') {
+  const { sessionToken } = result.actionRequired;
+  const verification = await startVerification(sessionToken!);
+  console.log('Verification result:', verification.type);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -649,6 +649,52 @@ Returns: `Promise<VerificationResult>`
 
 > **Note:** For advanced session parameters (`contactDetails`, `expectedDetails`, `metadata`), use the Backend Session method (`startVerification` with a token created via POST /v3/session/).
 
+### `submitTransaction(transactionToken, transaction, options?)`
+
+Submit a transaction directly from the device. Requires a transaction SDK token minted by your backend via `POST /v3/transactions/sdk-token/`. Device intelligence is attached automatically. If the response contains a required user action (verification session or wallet-ownership widget), the SDK auto-launches it natively and invokes `options.onTransactionUpdated` with the refreshed transaction once the action completes.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `transactionToken` | `string` | Yes | Transaction SDK token (sent as `X-Transaction-Token`) |
+| `transaction` | `DiditTransaction` | Yes | Transaction payload (`txnId` required; `info`, `subject`, `counterparty`, `travelRule`, ...) |
+| `options` | `DiditTransactionOptions` | No | `baseUrl`, `autoLaunchAction` (default `true`), `onTransactionUpdated` callback |
+
+Returns: `Promise<DiditTransactionResult>` with `transactionId`, `status`, `travelRuleStatus?`, and `actionRequired?`.
+
+Throws: `DiditTransactionError` with `code` set to `invalid_token`, `expired_token`, `validation` (see `fieldErrors`), or `network`.
+
+```tsx
+import { submitTransaction, DiditTransactionError } from '@didit-protocol/sdk-react-native';
+
+try {
+  const result = await submitTransaction(sdkToken, {
+    txnId: 'order-123',
+    type: 'crypto',
+    info: { direction: 'outbound', amount: 0.25, currency: 'ETH' },
+    travelRule: { required: true },
+  }, {
+    onTransactionUpdated: (updated) => console.log('Refreshed:', updated.status),
+  });
+  console.log(result.transactionId, result.actionRequired?.type);
+} catch (error) {
+  if (error instanceof DiditTransactionError) {
+    console.log(error.code, error.fieldErrors);
+  }
+}
+```
+
+### `getTransaction(transactionToken, transactionId, options?)`
+
+Fetch the current state of a transaction previously submitted with the same token.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `transactionToken` | `string` | Yes | Transaction SDK token |
+| `transactionId` | `string` | Yes | `transactionId` returned by `submitTransaction` |
+| `options` | `DiditTransactionOptions` | No | `baseUrl` override |
+
+Returns: `Promise<DiditTransactionResult>`
+
 ## Exported Types
 
 ```tsx
@@ -656,9 +702,14 @@ import {
   // Functions
   startVerification,
   startVerificationWithWorkflow,
+  submitTransaction,
+  getTransaction,
 
   // Enum
   VerificationStatus,
+
+  // Classes
+  DiditTransactionError,
 
   // Types
   type VerificationResult,
@@ -672,6 +723,15 @@ import {
   type ContactDetails,
   type ExpectedDetails,
   type WorkflowOptions,
+  type DiditTransaction,
+  type DiditTransactionInfo,
+  type DiditTransactionParticipant,
+  type DiditTransactionPaymentMethod,
+  type DiditTravelRule,
+  type DiditTransactionActionRequired,
+  type DiditTransactionResult,
+  type DiditTransactionOptions,
+  type DiditTransactionErrorCode,
 } from '@didit-protocol/sdk-react-native';
 ```
 

--- a/SdkReactNative.podspec
+++ b/SdkReactNative.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |s|
     ].join(" ")
   }
 
-  s.dependency didit_sdk_subspec, "~> 4.0"
+  s.dependency didit_sdk_subspec, "~> 4.1"
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,7 +119,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
 
   // Didit native Android SDK
-  implementation "me.didit:$diditSdkAndroidArtifact:4.0.2"
+  implementation "me.didit:$diditSdkAndroidArtifact:4.1.0"
 
   // Coroutines (required for state flow observation)
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"

--- a/android/src/main/java/com/sdkreactnative/SdkReactNativeModule.kt
+++ b/android/src/main/java/com/sdkreactnative/SdkReactNativeModule.kt
@@ -21,6 +21,10 @@ import me.didit.sdk.VerificationError
 import me.didit.sdk.VerificationResult
 import me.didit.sdk.VerificationStatus
 import me.didit.sdk.core.localization.SupportedLanguage
+import me.didit.sdk.transactions.DiditTransactionException
+import me.didit.sdk.transactions.DiditTransactionOptions
+import org.json.JSONException
+import org.json.JSONObject
 
 class SdkReactNativeModule(reactContext: ReactApplicationContext) :
     NativeSdkReactNativeSpec(reactContext) {
@@ -242,6 +246,82 @@ class SdkReactNativeModule(reactContext: ReactApplicationContext) :
         result.putString("errorType", "unknown")
         result.putString("errorMessage", e.message ?: "An unexpected error occurred.")
         promise.resolve(result)
+    }
+
+    // ─── Transactions ────────────────────────────────────────────────────────
+
+    override fun submitTransaction(
+        transactionToken: String,
+        transactionJson: String,
+        optionsJson: String,
+        promise: Promise
+    ) {
+        scope.launch {
+            try {
+                val payload = TransactionJson.parsePayload(transactionJson)
+                val options = JSONObject(optionsJson)
+                val callId = options.optString("callId")
+                val result = DiditSdk.submitTransaction(
+                    transactionToken = transactionToken,
+                    transaction = payload,
+                    options = DiditTransactionOptions(
+                        baseUrl = options.optString("baseUrl").takeIf { it.isNotEmpty() },
+                        autoLaunchAction = options.optBoolean("autoLaunchAction", true),
+                        onTransactionUpdated = { refreshed ->
+                            emitOnTransactionUpdated(TransactionJson.eventJson(callId, refreshed))
+                        }
+                    )
+                )
+                promise.resolve(TransactionJson.resultJson(result))
+            } catch (e: Exception) {
+                Log.e(TAG, "submitTransaction: exception", e)
+                rejectTransactionError(promise, e)
+            }
+        }
+    }
+
+    override fun getTransaction(
+        transactionToken: String,
+        transactionId: String,
+        optionsJson: String,
+        promise: Promise
+    ) {
+        scope.launch {
+            try {
+                val options = JSONObject(optionsJson)
+                val result = DiditSdk.getTransaction(
+                    transactionToken = transactionToken,
+                    transactionId = transactionId,
+                    options = DiditTransactionOptions(
+                        baseUrl = options.optString("baseUrl").takeIf { it.isNotEmpty() }
+                    )
+                )
+                promise.resolve(TransactionJson.resultJson(result))
+            } catch (e: Exception) {
+                Log.e(TAG, "getTransaction: exception", e)
+                rejectTransactionError(promise, e)
+            }
+        }
+    }
+
+    private fun rejectTransactionError(promise: Promise, e: Exception) {
+        when (e) {
+            is DiditTransactionException.InvalidToken ->
+                promise.reject("invalid_token", e.message, e)
+            is DiditTransactionException.ExpiredToken ->
+                promise.reject("expired_token", e.message, e)
+            is DiditTransactionException.Validation -> {
+                val userInfo = Arguments.createMap()
+                userInfo.putString("fieldErrors", JSONObject(e.fieldErrors).toString())
+                promise.reject("validation", e.message, e, userInfo)
+            }
+            is DiditTransactionException.Network ->
+                promise.reject("network", e.message, e)
+            is JSONException ->
+                promise.reject("validation", e.message ?: "Invalid transaction payload.", e)
+            else ->
+                promise.reject("network", e.message ?: "Transaction request failed.", e)
+        }
     }
 
     companion object {

--- a/android/src/main/java/com/sdkreactnative/TransactionJson.kt
+++ b/android/src/main/java/com/sdkreactnative/TransactionJson.kt
@@ -1,0 +1,129 @@
+package com.sdkreactnative
+
+import me.didit.sdk.transactions.DiditTransactionInfo
+import me.didit.sdk.transactions.DiditTransactionParticipant
+import me.didit.sdk.transactions.DiditTransactionPayload
+import me.didit.sdk.transactions.DiditTransactionPaymentMethod
+import me.didit.sdk.transactions.DiditTransactionResult
+import me.didit.sdk.transactions.DiditTravelRule
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Converts transaction payloads and results between the JSON strings used on
+ * the React Native bridge and the native SDK transaction models.
+ */
+internal object TransactionJson {
+
+    fun parsePayload(raw: String): DiditTransactionPayload {
+        val json = JSONObject(raw)
+        return DiditTransactionPayload(
+            txnId = json.getString("txnId"),
+            txnDate = json.stringOrNull("txnDate"),
+            zoneId = json.stringOrNull("zoneId"),
+            type = json.stringOrNull("type"),
+            info = json.optJSONObject("info")?.let(::parseInfo),
+            subject = json.optJSONObject("subject")?.let(::parseParticipant),
+            counterparty = json.optJSONObject("counterparty")?.let(::parseParticipant),
+            props = json.optJSONObject("props")?.toPlainMap(),
+            travelRule = json.optJSONObject("travelRule")?.let(::parseTravelRule),
+            includeCryptoScreening = json.booleanOrNull("includeCryptoScreening")
+        )
+    }
+
+    fun resultJson(result: DiditTransactionResult): String = resultObject(result).toString()
+
+    fun eventJson(callId: String, result: DiditTransactionResult): String =
+        JSONObject()
+            .put("callId", callId)
+            .put("result", resultObject(result))
+            .toString()
+
+    private fun parseInfo(json: JSONObject) = DiditTransactionInfo(
+        direction = json.stringOrNull("direction"),
+        amount = json.doubleOrNull("amount"),
+        currency = json.stringOrNull("currency"),
+        currencyType = json.stringOrNull("currencyType"),
+        amountInDefaultCurrency = json.doubleOrNull("amountInDefaultCurrency"),
+        defaultCurrencyCode = json.stringOrNull("defaultCurrencyCode"),
+        paymentDetails = json.stringOrNull("paymentDetails"),
+        paymentTxnId = json.stringOrNull("paymentTxnId"),
+        type = json.stringOrNull("type"),
+        cryptoParams = json.optJSONObject("cryptoParams")?.toPlainMap()
+    )
+
+    private fun parseParticipant(json: JSONObject) = DiditTransactionParticipant(
+        type = json.stringOrNull("type"),
+        externalUserId = json.stringOrNull("externalUserId"),
+        fullName = json.stringOrNull("fullName"),
+        firstName = json.stringOrNull("firstName"),
+        lastName = json.stringOrNull("lastName"),
+        dob = json.stringOrNull("dob"),
+        address = json.optJSONObject("address")?.toPlainMap(),
+        institutionInfo = json.optJSONObject("institutionInfo")?.toPlainMap(),
+        device = json.optJSONObject("device")?.toPlainMap(),
+        paymentMethod = json.optJSONObject("paymentMethod")?.let(::parsePaymentMethod)
+    )
+
+    private fun parsePaymentMethod(json: JSONObject) = DiditTransactionPaymentMethod(
+        type = json.stringOrNull("type"),
+        accountId = json.stringOrNull("accountId"),
+        issuingCountry = json.stringOrNull("issuingCountry")
+    )
+
+    private fun parseTravelRule(json: JSONObject) = DiditTravelRule(
+        status = json.stringOrNull("status"),
+        protocol = json.stringOrNull("protocol"),
+        required = json.booleanOrNull("required"),
+        obligationsCount = json.intOrNull("obligationsCount"),
+        originatorData = json.optJSONObject("originatorData")?.toPlainMap(),
+        beneficiaryData = json.optJSONObject("beneficiaryData")?.toPlainMap(),
+        metadata = json.optJSONObject("metadata")?.toPlainMap()
+    )
+
+    private fun resultObject(result: DiditTransactionResult): JSONObject {
+        val json = JSONObject()
+            .put("transactionId", result.transactionId)
+            .putOpt("status", result.status)
+            .putOpt("travelRuleStatus", result.travelRuleStatus)
+        result.actionRequired?.let { action ->
+            json.put(
+                "actionRequired",
+                JSONObject()
+                    .put("type", action.type)
+                    .putOpt("url", action.url)
+                    .putOpt("sessionId", action.sessionId)
+                    .putOpt("sessionToken", action.sessionToken)
+                    .putOpt("status", action.status)
+                    .putOpt("widgetSessionId", action.widgetSessionId)
+                    .putOpt("expiresAt", action.expiresAt)
+            )
+        }
+        return json
+    }
+
+    private fun JSONObject.stringOrNull(key: String): String? =
+        if (isNull(key)) null else optString(key)
+
+    private fun JSONObject.booleanOrNull(key: String): Boolean? =
+        if (isNull(key)) null else optBoolean(key)
+
+    private fun JSONObject.doubleOrNull(key: String): Double? =
+        if (isNull(key)) null else optDouble(key)
+
+    private fun JSONObject.intOrNull(key: String): Int? =
+        if (isNull(key)) null else optInt(key)
+
+    private fun JSONObject.toPlainMap(): Map<String, Any?> =
+        keys().asSequence().associateWith { key -> get(key).toPlainValue() }
+
+    private fun JSONArray.toPlainList(): List<Any?> =
+        (0 until length()).map { get(it).toPlainValue() }
+
+    private fun Any?.toPlainValue(): Any? = when (this) {
+        JSONObject.NULL -> null
+        is JSONObject -> toPlainMap()
+        is JSONArray -> toPlainList()
+        else -> this
+    }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,13 +14,22 @@ import {
   CameraLens,
   startVerification,
   startVerificationWithWorkflow,
+  submitTransaction,
+  DiditTransactionError,
   VerificationStatus,
   type VerificationResult,
+  type DiditTransactionResult,
 } from '@didit-protocol/sdk-react-native';
+
+const DEMO_WALLET_ADDRESS = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
 
 export default function App() {
   const [token, setToken] = useState('e5xD6RVXV19Q');
   const [workflowId, setWorkflowId] = useState('');
+  const [transactionToken, setTransactionToken] = useState('');
+  const [transactionResult, setTransactionResult] = useState<string | null>(
+    null
+  );
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<VerificationResult | null>(null);
 
@@ -80,6 +89,78 @@ export default function App() {
       setLoading(false);
     }
   }, [workflowId]);
+
+  const handleSubmitTransaction = useCallback(async () => {
+    if (!transactionToken.trim()) {
+      Alert.alert('Error', 'Please enter a transaction SDK token.');
+      return;
+    }
+
+    setLoading(true);
+    setTransactionResult(null);
+
+    try {
+      const txn = await submitTransaction(
+        transactionToken.trim(),
+        {
+          txnId: `rn-demo-${Date.now()}`,
+          txnDate: new Date().toISOString(),
+          type: 'crypto',
+          info: {
+            direction: 'outbound',
+            amount: 0.25,
+            currency: 'ETH',
+            currencyType: 'crypto',
+            cryptoParams: { address: DEMO_WALLET_ADDRESS, chain: 'ethereum' },
+          },
+          subject: {
+            type: 'individual',
+            externalUserId: 'rn-demo-user',
+            fullName: 'Ada Lovelace',
+          },
+          counterparty: {
+            type: 'individual',
+            fullName: 'Charles Babbage',
+            paymentMethod: {
+              type: 'crypto',
+              accountId: DEMO_WALLET_ADDRESS,
+              issuingCountry: 'GB',
+            },
+          },
+          travelRule: {
+            required: true,
+            originatorData: { full_name: 'Ada Lovelace' },
+            beneficiaryData: {
+              full_name: 'Charles Babbage',
+              wallet_address: DEMO_WALLET_ADDRESS,
+            },
+          },
+          includeCryptoScreening: true,
+        },
+        {
+          onTransactionUpdated: (updated: DiditTransactionResult) => {
+            setTransactionResult(
+              `Updated after action:\n${JSON.stringify(updated, null, 2)}`
+            );
+          },
+        }
+      );
+      setTransactionResult(JSON.stringify(txn, null, 2));
+    } catch (error) {
+      if (error instanceof DiditTransactionError) {
+        setTransactionResult(
+          `Error (${error.code}): ${error.message}` +
+            (error.fieldErrors
+              ? `\n${JSON.stringify(error.fieldErrors, null, 2)}`
+              : '')
+        );
+      } else {
+        setTransactionResult(`Unexpected error: ${error}`);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [transactionToken]);
 
   const showResultAlert = (res: VerificationResult) => {
     switch (res.type) {
@@ -162,6 +243,44 @@ export default function App() {
               <Text style={styles.buttonText}>Start with Workflow</Text>
             )}
           </TouchableOpacity>
+        </View>
+
+        {/* Transaction submission */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Submit Sample Transaction</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Enter transaction SDK token..."
+            placeholderTextColor="#999"
+            value={transactionToken}
+            onChangeText={setTransactionToken}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.buttonSecondary,
+              loading && styles.buttonDisabled,
+            ]}
+            onPress={handleSubmitTransaction}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>
+                Submit Travel-Rule Transaction
+              </Text>
+            )}
+          </TouchableOpacity>
+          {transactionResult && (
+            <View style={[styles.resultCard, styles.transactionResultCard]}>
+              <Text style={styles.transactionResultText}>
+                {transactionResult}
+              </Text>
+            </View>
+          )}
         </View>
 
         {/* Result display */}
@@ -295,5 +414,13 @@ const styles = StyleSheet.create({
   },
   statusDeclined: {
     color: '#dc2626',
+  },
+  transactionResultCard: {
+    marginTop: 12,
+  },
+  transactionResultText: {
+    fontSize: 12,
+    color: '#1a1a1a',
+    fontFamily: 'Courier',
   },
 });

--- a/ios/DiditSdkBridge.swift
+++ b/ios/DiditSdkBridge.swift
@@ -275,6 +275,210 @@ public class DiditSdkBridge: NSObject, @unchecked Sendable {
             return "unknown"
         }
     }
+
+    // MARK: - Transactions
+
+    /// Submit a transaction using a transaction SDK token.
+    /// Payload and options arrive as JSON strings from the TurboModule;
+    /// the result is delivered back as a JSON string.
+    public func submitTransaction(
+        transactionToken: String,
+        transactionJson: String,
+        optionsJson: String,
+        onUpdate: @escaping @Sendable (String) -> Void,
+        resolve: @escaping @Sendable (String) -> Void,
+        reject: @escaping @Sendable (String, String, NSDictionary?) -> Void
+    ) {
+        let payloadDict: [String: Any]
+        do {
+            payloadDict = try Self.jsonObject(from: transactionJson)
+        } catch {
+            reject("validation", "Invalid transaction payload: \(error.localizedDescription)", nil)
+            return
+        }
+        guard let txnId = payloadDict["txnId"] as? String, !txnId.isEmpty else {
+            reject("validation", "txnId is required", nil)
+            return
+        }
+        let payload = Self.transactionPayload(txnId: txnId, from: payloadDict)
+        let optionsDict = (try? Self.jsonObject(from: optionsJson)) ?? [:]
+        let callId = optionsDict["callId"] as? String ?? ""
+        let options = DiditTransactionOptions(
+            baseUrl: optionsDict["baseUrl"] as? String,
+            autoLaunchAction: optionsDict["autoLaunchAction"] as? Bool ?? true,
+            onTransactionUpdated: { result in
+                onUpdate(Self.transactionEventJson(callId: callId, result: result))
+            }
+        )
+        Task { @MainActor in
+            do {
+                let result = try await DiditSdk.shared.submitTransaction(
+                    transactionToken: transactionToken,
+                    transaction: payload,
+                    options: options
+                )
+                resolve(Self.transactionResultJson(result))
+            } catch {
+                Self.rejectTransaction(error, reject)
+            }
+        }
+    }
+
+    /// Fetch a transaction previously submitted with the same token.
+    public func getTransaction(
+        transactionToken: String,
+        transactionId: String,
+        optionsJson: String,
+        resolve: @escaping @Sendable (String) -> Void,
+        reject: @escaping @Sendable (String, String, NSDictionary?) -> Void
+    ) {
+        let optionsDict = (try? Self.jsonObject(from: optionsJson)) ?? [:]
+        let options = DiditTransactionOptions(baseUrl: optionsDict["baseUrl"] as? String)
+        Task { @MainActor in
+            do {
+                let result = try await DiditSdk.shared.getTransaction(
+                    transactionToken: transactionToken,
+                    transactionId: transactionId,
+                    options: options
+                )
+                resolve(Self.transactionResultJson(result))
+            } catch {
+                Self.rejectTransaction(error, reject)
+            }
+        }
+    }
+
+    // MARK: - Transaction JSON Mapping
+
+    private static func jsonObject(from raw: String) throws -> [String: Any] {
+        guard let data = raw.data(using: .utf8),
+              let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "me.didit.sdk.transactions",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Expected a JSON object"]
+            )
+        }
+        return json
+    }
+
+    private static func jsonString(_ object: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func transactionPayload(txnId: String, from dict: [String: Any]) -> DiditTransactionPayload {
+        DiditTransactionPayload(
+            txnId: txnId,
+            txnDate: dict["txnDate"] as? String,
+            zoneId: dict["zoneId"] as? String,
+            type: dict["type"] as? String,
+            info: (dict["info"] as? [String: Any]).map(transactionInfo),
+            subject: (dict["subject"] as? [String: Any]).map(transactionParticipant),
+            counterparty: (dict["counterparty"] as? [String: Any]).map(transactionParticipant),
+            props: dict["props"] as? [String: Any],
+            travelRule: (dict["travelRule"] as? [String: Any]).map(travelRule),
+            includeCryptoScreening: dict["includeCryptoScreening"] as? Bool
+        )
+    }
+
+    private static func transactionInfo(_ dict: [String: Any]) -> DiditTransactionInfo {
+        DiditTransactionInfo(
+            direction: dict["direction"] as? String,
+            amount: (dict["amount"] as? NSNumber)?.doubleValue,
+            currency: dict["currency"] as? String,
+            currencyType: dict["currencyType"] as? String,
+            amountInDefaultCurrency: (dict["amountInDefaultCurrency"] as? NSNumber)?.doubleValue,
+            defaultCurrencyCode: dict["defaultCurrencyCode"] as? String,
+            paymentDetails: dict["paymentDetails"] as? String,
+            paymentTxnId: dict["paymentTxnId"] as? String,
+            type: dict["type"] as? String,
+            cryptoParams: dict["cryptoParams"] as? [String: Any]
+        )
+    }
+
+    private static func transactionParticipant(_ dict: [String: Any]) -> DiditTransactionParticipant {
+        DiditTransactionParticipant(
+            type: dict["type"] as? String,
+            externalUserId: dict["externalUserId"] as? String,
+            fullName: dict["fullName"] as? String,
+            firstName: dict["firstName"] as? String,
+            lastName: dict["lastName"] as? String,
+            dob: dict["dob"] as? String,
+            address: dict["address"] as? [String: Any],
+            institutionInfo: dict["institutionInfo"] as? [String: Any],
+            device: dict["device"] as? [String: Any],
+            paymentMethod: (dict["paymentMethod"] as? [String: Any]).map { method in
+                DiditTransactionPaymentMethod(
+                    type: method["type"] as? String,
+                    accountId: method["accountId"] as? String,
+                    issuingCountry: method["issuingCountry"] as? String
+                )
+            }
+        )
+    }
+
+    private static func travelRule(_ dict: [String: Any]) -> DiditTravelRuleInfo {
+        DiditTravelRuleInfo(
+            status: dict["status"] as? String,
+            `protocol`: dict["protocol"] as? String,
+            required: dict["required"] as? Bool,
+            obligationsCount: (dict["obligationsCount"] as? NSNumber)?.intValue,
+            originatorData: dict["originatorData"] as? [String: Any],
+            beneficiaryData: dict["beneficiaryData"] as? [String: Any],
+            metadata: dict["metadata"] as? [String: Any]
+        )
+    }
+
+    private static func transactionResultObject(_ result: DiditTransactionResult) -> [String: Any] {
+        var json: [String: Any] = ["transactionId": result.transactionId]
+        json["status"] = result.status
+        json["travelRuleStatus"] = result.travelRuleStatus
+        if let action = result.actionRequired {
+            var actionJson: [String: Any] = ["type": action.type]
+            actionJson["url"] = action.url
+            actionJson["sessionId"] = action.sessionId
+            actionJson["sessionToken"] = action.sessionToken
+            actionJson["status"] = action.status
+            actionJson["widgetSessionId"] = action.widgetSessionId
+            actionJson["expiresAt"] = action.expiresAt
+            json["actionRequired"] = actionJson
+        }
+        return json
+    }
+
+    private static func transactionResultJson(_ result: DiditTransactionResult) -> String {
+        jsonString(transactionResultObject(result))
+    }
+
+    private static func transactionEventJson(callId: String, result: DiditTransactionResult) -> String {
+        jsonString(["callId": callId, "result": transactionResultObject(result)])
+    }
+
+    private static func rejectTransaction(
+        _ error: Error,
+        _ reject: (String, String, NSDictionary?) -> Void
+    ) {
+        guard let transactionError = error as? DiditTransactionError else {
+            reject("network", error.localizedDescription, nil)
+            return
+        }
+        let message = transactionError.errorDescription ?? "Transaction request failed"
+        switch transactionError {
+        case .invalidToken:
+            reject("invalid_token", message, nil)
+        case .expiredToken:
+            reject("expired_token", message, nil)
+        case .validation(let fieldErrors):
+            reject("validation", message, ["fieldErrors": jsonString(fieldErrors)])
+        case .network:
+            reject("network", message, nil)
+        }
+    }
 }
 
 // MARK: - SwiftUI Bridge View

--- a/ios/SdkReactNative.h
+++ b/ios/SdkReactNative.h
@@ -1,5 +1,5 @@
 #import <SdkReactNativeSpec/SdkReactNativeSpec.h>
 
-@interface SdkReactNative : NSObject <NativeSdkReactNativeSpec>
+@interface SdkReactNative : NativeSdkReactNativeSpecBase <NativeSdkReactNativeSpec>
 
 @end

--- a/ios/SdkReactNative.mm
+++ b/ios/SdkReactNative.mm
@@ -132,6 +132,58 @@
     }];
 }
 
+// MARK: - Transactions
+
+static NSError *DiditTransactionNSError(NSString *message, NSDictionary *userInfoFields)
+{
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    if (message) {
+        userInfo[NSLocalizedDescriptionKey] = message;
+    }
+    if (userInfoFields) {
+        [userInfo addEntriesFromDictionary:userInfoFields];
+    }
+    return [NSError errorWithDomain:@"me.didit.sdk.transactions" code:0 userInfo:userInfo];
+}
+
+- (void)submitTransaction:(NSString *)transactionToken
+          transactionJson:(NSString *)transactionJson
+              optionsJson:(NSString *)optionsJson
+                  resolve:(RCTPromiseResolveBlock)resolve
+                   reject:(RCTPromiseRejectBlock)reject
+{
+    __weak SdkReactNative *weakSelf = self;
+    [_bridge submitTransactionWithTransactionToken:transactionToken
+                                   transactionJson:transactionJson
+                                       optionsJson:optionsJson
+                                          onUpdate:^(NSString *eventJson) {
+        [weakSelf emitOnTransactionUpdated:eventJson];
+    }
+                                           resolve:^(NSString *resultJson) {
+        resolve(resultJson);
+    }
+                                            reject:^(NSString *code, NSString *message, NSDictionary *userInfoFields) {
+        reject(code, message, DiditTransactionNSError(message, userInfoFields));
+    }];
+}
+
+- (void)getTransaction:(NSString *)transactionToken
+         transactionId:(NSString *)transactionId
+           optionsJson:(NSString *)optionsJson
+               resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject
+{
+    [_bridge getTransactionWithTransactionToken:transactionToken
+                                  transactionId:transactionId
+                                    optionsJson:optionsJson
+                                        resolve:^(NSString *resultJson) {
+        resolve(resultJson);
+    }
+                                         reject:^(NSString *code, NSString *message, NSDictionary *userInfoFields) {
+        reject(code, message, DiditTransactionNSError(message, userInfoFields));
+    }];
+}
+
 // MARK: - TurboModule Registration
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/src/NativeSdkReactNative.ts
+++ b/src/NativeSdkReactNative.ts
@@ -1,4 +1,8 @@
-import { TurboModuleRegistry, type TurboModule } from 'react-native';
+import {
+  TurboModuleRegistry,
+  type CodegenTypes,
+  type TurboModule,
+} from 'react-native';
 
 /**
  * Configuration for the Didit verification SDK.
@@ -96,6 +100,33 @@ export interface Spec extends TurboModule {
     expectedDetails: ExpectedDetails | null,
     config: VerificationConfig | null
   ): Promise<VerificationResultJS>;
+
+  /**
+   * Submit a transaction from the device using a transaction SDK token.
+   * The transaction payload and options cross the bridge as JSON strings;
+   * the resolved value is the transaction result as a JSON string.
+   */
+  submitTransaction(
+    transactionToken: string,
+    transactionJson: string,
+    optionsJson: string
+  ): Promise<string>;
+
+  /**
+   * Fetch a transaction previously submitted with the same token.
+   * The resolved value is the transaction result as a JSON string.
+   */
+  getTransaction(
+    transactionToken: string,
+    transactionId: string,
+    optionsJson: string
+  ): Promise<string>;
+
+  /**
+   * Fired after an auto-launched action completes and the transaction has
+   * been refreshed. Payload is a JSON string: { callId, result }.
+   */
+  readonly onTransactionUpdated: CodegenTypes.EventEmitter<string>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SdkReactNative');

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,96 @@
-it.todo('write a test');
+import type { DiditTransactionResult } from '../types';
+
+jest.mock('../NativeSdkReactNative', () => ({
+  __esModule: true,
+  default: {
+    submitTransaction: jest.fn(),
+    getTransaction: jest.fn(),
+    onTransactionUpdated: jest.fn(),
+  },
+}));
+
+import NativeSdkReactNative from '../NativeSdkReactNative';
+import { submitTransaction, getTransaction } from '../index';
+
+const mockSubmit = NativeSdkReactNative.submitTransaction as jest.Mock;
+const mockGet = NativeSdkReactNative.getTransaction as jest.Mock;
+
+describe('transaction result marshalling', () => {
+  beforeEach(() => {
+    mockSubmit.mockReset();
+    mockGet.mockReset();
+  });
+
+  it('surfaces actionRequired for a verification_session action, not just wallet_ownership', async () => {
+    const nativeResult: DiditTransactionResult = {
+      transactionId: 'txn-1',
+      status: 'pending',
+      actionRequired: {
+        type: 'verification_session',
+        url: 'https://verify.didit.me/session/abc',
+        sessionId: 'session-abc',
+        sessionToken: 'session-token-abc',
+        status: 'Not Started',
+      },
+    };
+    mockSubmit.mockResolvedValue(JSON.stringify(nativeResult));
+
+    const result = await submitTransaction('txn-token', { txnId: 'order-1' });
+
+    // The host app relies on sessionId/sessionToken being present here to
+    // launch its own verification flow - this must never be dropped or
+    // gated behind the action type.
+    expect(result.actionRequired).toEqual(nativeResult.actionRequired);
+  });
+
+  it('still surfaces actionRequired for wallet_ownership (regression)', async () => {
+    const nativeResult: DiditTransactionResult = {
+      transactionId: 'txn-2',
+      status: 'pending',
+      actionRequired: {
+        type: 'wallet_ownership',
+        url: 'https://verify.didit.me/wallet/xyz',
+        widgetSessionId: 'widget-xyz',
+        expiresAt: '2026-08-01T00:00:00Z',
+      },
+    };
+    mockSubmit.mockResolvedValue(JSON.stringify(nativeResult));
+
+    const result = await submitTransaction('txn-token', { txnId: 'order-2' });
+
+    expect(result.actionRequired).toEqual(nativeResult.actionRequired);
+  });
+
+  it('passes autoLaunchAction straight through to native with no JS-side gating', async () => {
+    mockSubmit.mockResolvedValue(
+      JSON.stringify({ transactionId: 'txn-3', status: 'pending' })
+    );
+
+    await submitTransaction(
+      'txn-token',
+      { txnId: 'order-3' },
+      { autoLaunchAction: false }
+    );
+
+    const [, , optionsJson] = mockSubmit.mock.calls[0];
+    expect(JSON.parse(optionsJson)).toMatchObject({ autoLaunchAction: false });
+  });
+
+  it('getTransaction surfaces actionRequired for a verification_session action', async () => {
+    const nativeResult: DiditTransactionResult = {
+      transactionId: 'txn-4',
+      status: 'pending',
+      actionRequired: {
+        type: 'verification_session',
+        sessionId: 'session-def',
+        sessionToken: 'session-token-def',
+        status: 'Not Started',
+      },
+    };
+    mockGet.mockResolvedValue(JSON.stringify(nativeResult));
+
+    const result = await getTransaction('txn-token', 'txn-4');
+
+    expect(result.actionRequired).toEqual(nativeResult.actionRequired);
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,19 @@
+import type { EventSubscription } from 'react-native';
 import NativeSdkReactNative from './NativeSdkReactNative';
 import type { VerificationResultJS } from './NativeSdkReactNative';
-import { VerificationStatus } from './types';
-import type { VerificationResult, DiditConfig, WorkflowOptions } from './types';
+import { VerificationStatus, DiditTransactionError } from './types';
+import type {
+  VerificationResult,
+  DiditConfig,
+  WorkflowOptions,
+  DiditTransaction,
+  DiditTransactionErrorCode,
+  DiditTransactionOptions,
+  DiditTransactionResult,
+} from './types';
 
 // Re-export all public types
-export { VerificationStatus, CameraLens } from './types';
+export { VerificationStatus, CameraLens, DiditTransactionError } from './types';
 export type {
   VerificationResult,
   VerificationCompleted,
@@ -17,6 +26,15 @@ export type {
   ContactDetails,
   ExpectedDetails,
   WorkflowOptions,
+  DiditTransaction,
+  DiditTransactionInfo,
+  DiditTransactionParticipant,
+  DiditTransactionPaymentMethod,
+  DiditTravelRule,
+  DiditTransactionActionRequired,
+  DiditTransactionResult,
+  DiditTransactionOptions,
+  DiditTransactionErrorCode,
 } from './types';
 
 // ─── Internal Helpers ────────────────────────────────────────────────────────
@@ -222,4 +240,176 @@ export async function startVerificationWithWorkflow(
   );
 
   return mapNativeResult(raw);
+}
+
+// ─── Transactions ────────────────────────────────────────────────────────────
+
+const TRANSACTION_ERROR_CODES: DiditTransactionErrorCode[] = [
+  'invalid_token',
+  'expired_token',
+  'validation',
+  'network',
+];
+
+let transactionCallCounter = 0;
+let transactionUpdateSubscription: EventSubscription | null = null;
+const pendingTransactionUpdates = new Map<
+  string,
+  (result: DiditTransactionResult) => void
+>();
+
+/**
+ * Dispatches native transaction-updated events to the callback registered
+ * for the originating call. A single module-level subscription is shared
+ * by all in-flight calls and events are matched by `callId`.
+ */
+function registerTransactionUpdate(
+  callId: string,
+  callback: (result: DiditTransactionResult) => void
+): void {
+  if (!transactionUpdateSubscription) {
+    transactionUpdateSubscription = NativeSdkReactNative.onTransactionUpdated(
+      (payload: string) => {
+        let event: { callId?: string; result?: DiditTransactionResult };
+        try {
+          event = JSON.parse(payload);
+        } catch {
+          return;
+        }
+        if (!event.callId || !event.result) {
+          return;
+        }
+        const pending = pendingTransactionUpdates.get(event.callId);
+        if (pending) {
+          pendingTransactionUpdates.delete(event.callId);
+          pending(event.result);
+        }
+      }
+    );
+  }
+  pendingTransactionUpdates.set(callId, callback);
+}
+
+/**
+ * Normalizes a native module rejection into a DiditTransactionError with a
+ * stable `code` field and parsed `fieldErrors` for validation failures.
+ */
+function toTransactionError(error: unknown): DiditTransactionError {
+  if (error instanceof DiditTransactionError) {
+    return error;
+  }
+  const raw = error as {
+    code?: string;
+    message?: string;
+    userInfo?: { fieldErrors?: string };
+  } | null;
+  const code = TRANSACTION_ERROR_CODES.includes(
+    raw?.code as DiditTransactionErrorCode
+  )
+    ? (raw?.code as DiditTransactionErrorCode)
+    : 'network';
+  let fieldErrors: Record<string, unknown> | undefined;
+  if (raw?.userInfo?.fieldErrors) {
+    try {
+      fieldErrors = JSON.parse(raw.userInfo.fieldErrors);
+    } catch {
+      fieldErrors = undefined;
+    }
+  }
+  return new DiditTransactionError(
+    code,
+    raw?.message ?? 'Transaction request failed.',
+    fieldErrors
+  );
+}
+
+/**
+ * Submit a transaction directly from the device.
+ *
+ * Requires a transaction SDK token minted by your backend via
+ * `POST /v3/transactions/sdk-token/`. Device intelligence is attached
+ * automatically. If the response contains a required user action
+ * (verification session or wallet-ownership widget) and
+ * `options.autoLaunchAction` is not disabled, the SDK launches it natively
+ * and later invokes `options.onTransactionUpdated` with the refreshed
+ * transaction.
+ *
+ * @param transactionToken - Transaction SDK token (X-Transaction-Token).
+ * @param transaction - The transaction payload (camelCase wire contract).
+ * @param options - Optional base URL override, auto-launch flag, and update callback.
+ * @returns A promise that resolves with the created transaction.
+ * @throws {DiditTransactionError} With `code` set to `invalid_token`,
+ *   `expired_token`, `validation` (see `fieldErrors`), or `network`.
+ *
+ * @example
+ * ```ts
+ * import { submitTransaction } from '@didit-protocol/sdk-react-native';
+ *
+ * const result = await submitTransaction(sdkToken, {
+ *   txnId: 'order-123',
+ *   type: 'crypto',
+ *   info: { direction: 'outbound', amount: 0.25, currency: 'ETH' },
+ *   travelRule: { required: true },
+ * }, {
+ *   onTransactionUpdated: (updated) => console.log(updated.status),
+ * });
+ * console.log(result.transactionId, result.actionRequired?.type);
+ * ```
+ */
+export async function submitTransaction(
+  transactionToken: string,
+  transaction: DiditTransaction,
+  options?: DiditTransactionOptions
+): Promise<DiditTransactionResult> {
+  const callId = `txn-${Date.now()}-${++transactionCallCounter}`;
+  const autoLaunchAction = options?.autoLaunchAction ?? true;
+  if (autoLaunchAction && options?.onTransactionUpdated) {
+    registerTransactionUpdate(callId, options.onTransactionUpdated);
+  }
+  try {
+    const resultJson = await NativeSdkReactNative.submitTransaction(
+      transactionToken,
+      JSON.stringify(transaction),
+      JSON.stringify({
+        callId,
+        autoLaunchAction,
+        baseUrl: options?.baseUrl,
+      })
+    );
+    const result = JSON.parse(resultJson) as DiditTransactionResult;
+    if (!result.actionRequired) {
+      pendingTransactionUpdates.delete(callId);
+    }
+    return result;
+  } catch (error) {
+    pendingTransactionUpdates.delete(callId);
+    throw toTransactionError(error);
+  }
+}
+
+/**
+ * Fetch a transaction previously submitted with the same transaction token.
+ *
+ * @param transactionToken - Transaction SDK token (X-Transaction-Token).
+ * @param transactionId - The `transactionId` returned by {@link submitTransaction}.
+ * @param options - Optional base URL override.
+ * @returns A promise that resolves with the current transaction state.
+ * @throws {DiditTransactionError} With `code` set to `invalid_token`,
+ *   `expired_token`, `validation`, or `network`.
+ */
+export async function getTransaction(
+  transactionToken: string,
+  transactionId: string,
+  options?: DiditTransactionOptions
+): Promise<DiditTransactionResult> {
+  try {
+    const resultJson = await NativeSdkReactNative.getTransaction(
+      transactionToken,
+      transactionId,
+      JSON.stringify({ baseUrl: options?.baseUrl })
+    );
+    return JSON.parse(resultJson) as DiditTransactionResult;
+  } catch (error) {
+    throw toTransactionError(error);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,3 +224,162 @@ export interface WorkflowOptions {
   /** SDK configuration options. */
   config?: DiditConfig;
 }
+
+// ─── Transactions ────────────────────────────────────────────────────────────
+
+/**
+ * Monetary or crypto details of a transaction.
+ */
+export interface DiditTransactionInfo {
+  /** Transaction direction, e.g. "inbound" or "outbound". */
+  direction?: string;
+  amount?: number;
+  /** Currency code, e.g. "USD" or "ETH". */
+  currency?: string;
+  /** Currency type, e.g. "fiat" or "crypto". */
+  currencyType?: string;
+  amountInDefaultCurrency?: number;
+  defaultCurrencyCode?: string;
+  paymentDetails?: string;
+  paymentTxnId?: string;
+  type?: string;
+  /** Crypto transfer parameters, e.g. { address, chain }. */
+  cryptoParams?: Record<string, unknown>;
+}
+
+/**
+ * Payment method of a transaction participant.
+ */
+export interface DiditTransactionPaymentMethod {
+  type?: string;
+  /** Account identifier, e.g. an IBAN, card fingerprint, or wallet address. */
+  accountId?: string;
+  /** ISO 3166-1 alpha-2 issuing country. */
+  issuingCountry?: string;
+}
+
+/**
+ * A transaction participant (subject or counterparty).
+ */
+export interface DiditTransactionParticipant {
+  /** Participant type, e.g. "individual" or "company". */
+  type?: string;
+  externalUserId?: string;
+  fullName?: string;
+  firstName?: string;
+  lastName?: string;
+  /** Date of birth (ISO 8601 date). */
+  dob?: string;
+  address?: Record<string, unknown>;
+  institutionInfo?: Record<string, unknown>;
+  device?: Record<string, unknown>;
+  paymentMethod?: DiditTransactionPaymentMethod;
+}
+
+/**
+ * Travel rule information attached to a transaction.
+ */
+export interface DiditTravelRule {
+  status?: string;
+  protocol?: string;
+  required?: boolean;
+  obligationsCount?: number;
+  originatorData?: Record<string, unknown>;
+  beneficiaryData?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * A transaction to submit from the device.
+ * Mirrors the Didit transaction wire contract (camelCase aliases).
+ */
+export interface DiditTransaction {
+  /** Your unique transaction identifier. */
+  txnId: string;
+  /** Transaction timestamp (ISO 8601). */
+  txnDate?: string;
+  /** Time zone identifier, e.g. "Europe/Madrid". */
+  zoneId?: string;
+  /** Transaction category, e.g. "crypto". */
+  type?: string;
+  info?: DiditTransactionInfo;
+  subject?: DiditTransactionParticipant;
+  counterparty?: DiditTransactionParticipant;
+  /** Custom properties attached to the transaction. */
+  props?: Record<string, unknown>;
+  travelRule?: DiditTravelRule;
+  includeCryptoScreening?: boolean;
+}
+
+/**
+ * A user action required to complete the transaction.
+ */
+export interface DiditTransactionActionRequired {
+  /** Action type: "verification_session" or "wallet_ownership". */
+  type: string;
+  /** Hosted URL to complete the action. */
+  url?: string;
+  sessionId?: string;
+  sessionToken?: string;
+  status?: string;
+  widgetSessionId?: string;
+  /** Expiry timestamp of the wallet-ownership widget session. */
+  expiresAt?: string;
+}
+
+/**
+ * The result of a submitted or fetched transaction.
+ */
+export interface DiditTransactionResult {
+  transactionId: string;
+  status?: string;
+  travelRuleStatus?: string;
+  actionRequired?: DiditTransactionActionRequired;
+}
+
+/**
+ * Options for submitting or fetching a transaction.
+ */
+export interface DiditTransactionOptions {
+  /** Override the verification API base URL. */
+  baseUrl?: string;
+  /**
+   * Automatically launch any required user action (verification session
+   * or wallet-ownership widget). Default: `true`.
+   */
+  autoLaunchAction?: boolean;
+  /**
+   * Called with the refreshed transaction after an auto-launched action
+   * completes and the transaction status has been re-fetched.
+   */
+  onTransactionUpdated?: (result: DiditTransactionResult) => void;
+}
+
+/**
+ * Error categories thrown by {@link submitTransaction} and {@link getTransaction}.
+ */
+export type DiditTransactionErrorCode =
+  | 'invalid_token'
+  | 'expired_token'
+  | 'validation'
+  | 'network';
+
+/**
+ * Typed error thrown by the transaction methods. Use the `code` field to
+ * discriminate; `fieldErrors` carries per-field details for `validation`.
+ */
+export class DiditTransactionError extends Error {
+  readonly code: DiditTransactionErrorCode;
+  readonly fieldErrors?: Record<string, unknown>;
+
+  constructor(
+    code: DiditTransactionErrorCode,
+    message: string,
+    fieldErrors?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'DiditTransactionError';
+    this.code = code;
+    this.fieldErrors = fieldErrors;
+  }
+}


### PR DESCRIPTION
## Summary
- TS surface submitTransaction/getTransaction with full wire-contract types and DiditTransactionError (4 stable codes + fieldErrors).
- TurboModule bridge marshals payload/result as JSON; codegen event emitter onTransactionUpdated dispatches post-action refreshed results per call.
- Native pins bumped to me.didit:didit-sdk 4.1.0 / pod ~> 4.1 (first native release containing the transaction API).

## Testing
- yarn typecheck, lint, jest green; bob build + full RN codegen succeeded (generated specs match the handwritten native signatures).
- Native compilation awaits the 4.1.0 native SDK release (no local-path override exists); signatures written against mobile-sdks feature/sdk-transaction-submission source.

Depends on mobile-sdks PR #9 being released as 4.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)