### PR TITLE
fix(expo): derive iOS podspec URL from a declared native SDK version (#28)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,19 @@ To publish new versions, run the following:
 yarn release
 ```
 
+### Bumping the native SDK version
+
+The wrapper version (`version` in `package.json`) and the native Didit SDK version are independent - a wrapper-only fix ships without a new native release. The native versions live in `diditNativeSdkVersions`:
+
+```json
+"diditNativeSdkVersions": {
+  "ios": "4.3.1",
+  "android": "4.3.1"
+}
+```
+
+`SdkReactNative.podspec` and `app.plugin.js` both derive the iOS pin from `diditNativeSdkVersions.ios`, so bumping it there is enough to move the podspec dependency and the sdk-ios podspec URL together. The remaining hand-maintained pins - `android/build.gradle`, the README podspec URL, and the example Podfiles - are asserted against these values by `src/__tests__/native-sdk-pins.test.ts`, so `yarn test` fails if any of them drift (see issues #19 and #28). Only bump `diditNativeSdkVersions.ios` once the matching tag exists in `didit-protocol/sdk-ios`.
+
 
 ### Scripts
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ That's it. The plugin automatically configures both platforms:
 
 Supported `iosVariant` / `androidVariant` values are `all`, `core`, `autodetection`, and `nfc`. The legacy booleans (`iosNfcEnabled`, `iosAutoDetectionEnabled`, `androidNfcEnabled`) still work, but `iosVariant` / `androidVariant` are preferred for new integrations.
 
+The iOS podspec URL is derived from the native SDK version this package pins (`diditNativeSdkVersions.ios` in its `package.json`), so it always matches the `DiditSDK` version the podspec depends on. To point CocoaPods at a fork, mirror, or prerelease tag instead, pass `iosPodspecUrl`:
+
+```json
+[
+  "@didit-protocol/sdk-react-native",
+  {
+    "iosPodspecUrl": "https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec"
+  }
+]
+```
+
 > **Note:** This SDK uses native modules (camera, NFC) that are not available in Expo Go. You must use a [development build](https://docs.expo.dev/develop/development-builds/introduction/) or run `npx expo prebuild` to generate the native projects.
 
 ### React Native CLI

--- a/SdkReactNative.podspec
+++ b/SdkReactNative.podspec
@@ -2,6 +2,15 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+# Single source of truth for the native iOS SDK version, shared with
+# app.plugin.js (which builds the sdk-ios podspec URL from it). Hardcoding it
+# here lets the two drift apart, which makes `pod install` unresolvable for
+# every consumer - see issues #19 and #28.
+didit_sdk_ios_version = package.dig("diditNativeSdkVersions", "ios").to_s
+if didit_sdk_ios_version.empty?
+  raise "Missing 'diditNativeSdkVersions.ios' in package.json - cannot pin the Didit iOS SDK."
+end
+
 legacy_nfc_enabled            = ENV.fetch("DIDIT_SDK_IOS_NFC_ENABLED",            "true").downcase != "false"
 legacy_auto_detection_enabled = ENV.fetch("DIDIT_SDK_IOS_AUTO_DETECTION_ENABLED", "true").downcase != "false"
 legacy_variant = case [legacy_nfc_enabled, legacy_auto_detection_enabled]
@@ -60,7 +69,7 @@ Pod::Spec.new do |s|
     ].join(" ")
   }
 
-  s.dependency didit_sdk_subspec, "4.3.1"
+  s.dependency didit_sdk_subspec, didit_sdk_ios_version
 
   install_modules_dependencies(s)
 end

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -85,7 +85,17 @@ function normalizePodspecUrl(value) {
   if (typeof value !== 'string' || value.trim() === '') {
     return DEFAULT_PODSPEC_URL;
   }
-  return value.trim();
+
+  const url = value.trim();
+  if (url.includes("'")) {
+    // The URL is emitted inside a single-quoted Ruby string; a stray quote
+    // would produce a Podfile that fails to parse rather than a clear error.
+    throw new Error(
+      `@didit-protocol/sdk-react-native: invalid "iosPodspecUrl" (${url}) - it must not contain a single quote.`
+    );
+  }
+
+  return url;
 }
 
 function diditPodBlock(iosVariant, podspecUrl, isRubyExpression = false) {

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -11,13 +11,34 @@ const {
   mergeContents,
 } = require('@expo/config-plugins/build/utils/generateCode');
 
+const pkg = require('./package.json');
+
 const MAVEN_REPO =
   'https://raw.githubusercontent.com/didit-protocol/sdk-android/main/repository';
 
 const MAVEN_LINE = `        maven { url "${MAVEN_REPO}" }`;
 
-const PODSPEC_URL =
-  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.1.0/DiditSDK.podspec';
+/**
+ * The native iOS SDK is not published to the CocoaPods trunk, so its podspec is
+ * fetched straight from the sdk-ios repo at a tagged version.
+ *
+ * That version MUST be the one `SdkReactNative.podspec` depends on, otherwise
+ * CocoaPods sees two incompatible requirements for `DiditSDK` and every
+ * `pod install` fails. Both read `diditNativeSdkVersions.ios` from package.json
+ * for exactly that reason - a URL hardcoded here silently drifts out of sync on
+ * the next release (issues #19 and #28).
+ */
+const IOS_SDK_VERSION =
+  pkg.diditNativeSdkVersions && pkg.diditNativeSdkVersions.ios;
+
+if (!IOS_SDK_VERSION) {
+  throw new Error(
+    '@didit-protocol/sdk-react-native: missing "diditNativeSdkVersions.ios" in package.json - ' +
+      'the Didit iOS SDK podspec URL cannot be resolved.'
+  );
+}
+
+const DEFAULT_PODSPEC_URL = `https://raw.githubusercontent.com/didit-protocol/sdk-ios/${IOS_SDK_VERSION}/DiditSDK.podspec`;
 
 const VALID_VARIANTS = ['all', 'core', 'autodetection', 'nfc'];
 const PODFILE_PROPS_KEY = 'didit.iosVariant';
@@ -52,10 +73,22 @@ function normalizeOptions(props = {}) {
       legacyAndroidVariant
     ),
     iosVariant: normalizeVariant(props.iosVariant, legacyIosVariant),
+    iosPodspecUrl: normalizePodspecUrl(props.iosPodspecUrl),
   };
 }
 
-function diditPodBlock(iosVariant, isRubyExpression = false) {
+/**
+ * Escape hatch for consumers who need to point CocoaPods at a different
+ * DiditSDK podspec (a fork, a mirror, or a prerelease tag).
+ */
+function normalizePodspecUrl(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return DEFAULT_PODSPEC_URL;
+  }
+  return value.trim();
+}
+
+function diditPodBlock(iosVariant, podspecUrl, isRubyExpression = false) {
   const variantAssignment = isRubyExpression
     ? `  $DiditSdkIosVariant = ${iosVariant}`
     : `  $DiditSdkIosVariant = '${iosVariant}'`;
@@ -69,7 +102,7 @@ function diditPodBlock(iosVariant, isRubyExpression = false) {
     '                      else',
     '                        raise "Invalid $DiditSdkIosVariant \'#{$DiditSdkIosVariant}\'. Supported values: all, core, autodetection, nfc."',
     '                      end',
-    `  pod didit_sdk_subspec, :podspec => '${PODSPEC_URL}'`,
+    `  pod didit_sdk_subspec, :podspec => '${podspecUrl}'`,
   ].join('\n');
 }
 
@@ -219,9 +252,10 @@ function withDiditIosPodspec(config, options) {
     const newSrc = isExpoPodfile
       ? diditPodBlock(
           `podfile_properties.fetch('${PODFILE_PROPS_KEY}', '${options.iosVariant}')`,
+          options.iosPodspecUrl,
           true
         )
-      : diditPodBlock(options.iosVariant);
+      : diditPodBlock(options.iosVariant, options.iosPodspecUrl);
 
     const result = mergeContents({
       tag: POD_BLOCK_TAG,
@@ -258,7 +292,5 @@ function withDiditSdk(config, props) {
   config = withDiditIosPodspec(config, options);
   return config;
 }
-
-const pkg = require('./package.json');
 
 module.exports = createRunOncePlugin(withDiditSdk, pkg.name, pkg.version);

--- a/example-expo/ios/DiditExpoExample.xcodeproj/project.pbxproj
+++ b/example-expo/ios/DiditExpoExample.xcodeproj/project.pbxproj
@@ -275,8 +275,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-DiditExpoExample/Pods-DiditExpoExample-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/DiditSDK/Full/DiditSDK.framework/DiditSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/DiditSDK/Full/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/DiditSDK/All/DiditSDK.framework/DiditSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/DiditSDK/All/OpenSSL.framework/OpenSSL",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt/React.framework/React",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies/ReactNativeDependencies.framework/ReactNativeDependencies",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermesvm.framework/hermesvm",

--- a/example-expo/ios/Podfile
+++ b/example-expo/ios/Podfile
@@ -30,7 +30,7 @@ target 'DiditExpoExample' do
                       else
                         raise "Invalid $DiditSdkIosVariant '#{$DiditSdkIosVariant}'. Supported values: all, core, autodetection, nfc."
                       end
-  pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.1.0/DiditSDK.podspec'
+  pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec'
 
   use_expo_modules!
 

--- a/example-expo/ios/Podfile.lock
+++ b/example-expo/ios/Podfile.lock
@@ -1,7 +1,5 @@
 PODS:
-  - DiditSDK (3.5.1):
-    - DiditSDK/Full (= 3.5.1)
-  - DiditSDK/Full (3.5.1)
+  - DiditSDK/All (4.3.1)
   - EXConstants (55.0.14):
     - ExpoModulesCore
   - Expo (55.0.15):
@@ -1851,8 +1849,8 @@ PODS:
     - React-utils (= 0.83.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.83.0)
-  - SdkReactNative (3.3.0):
-    - DiditSDK (~> 3.5)
+  - SdkReactNative (4.3.1):
+    - DiditSDK/All (= 4.3.1)
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1877,7 +1875,7 @@ PODS:
   - Yoga (0.0.0)
 
 DEPENDENCIES:
-  - DiditSDK (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec`)
+  - DiditSDK/All (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - Expo (from `../node_modules/expo`)
   - ExpoAsset (from `../node_modules/expo-asset/ios`)
@@ -1966,7 +1964,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   DiditSDK:
-    :podspec: https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec
+    :podspec: https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec
   EXConstants:
     :path: "../node_modules/expo-constants/ios"
   Expo:
@@ -2138,7 +2136,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  DiditSDK: 27173cbfc13db575640538a978d3ecf983b047ba
+  DiditSDK: 915df5557629af1796d99cfb05ca6732d80b08b9
   EXConstants: bfe4ae4e5d882e2e0b130e049665d0af4f4cc1b8
   Expo: a43f44ff1e3a1c73fcabba766e13a38dea22236a
   ExpoAsset: dc4f25f84886120f82b23233bba563ea7afa88f5
@@ -2150,7 +2148,7 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 04cfca35843acea9499480d2c6fa7369831c66ab
   ExpoModulesJSI: 4f9a951679fdfbfca1e4feb5c1e10df045333a5a
   FBLazyVector: 7c1d69992204c5ec452eeefa4a24b0ff311709c8
-  hermes-engine: ec92932e1fe5813453ea3cafb32551a68d95854f
+  hermes-engine: b743399f8ce585a1d9eefac985305ab575defeb0
   RCTDeprecation: dbbb85eae640e3b43cc16462d0476b00ca5959ae
   RCTRequired: 7047b18af29a76069818fd3fa0f4df423483abab
   RCTSwiftUI: 5928f7ca7e9e2f1a82d85d4c79ea3065137ad81c
@@ -2159,7 +2157,7 @@ SPEC CHECKSUMS:
   React: f6f8fc5c01e77349cdfaf49102bcb928ac31d8ed
   React-callinvoker: 3e62a849bda1522c6422309c02f5dc3210bc5359
   React-Core: 107092273c9178bb015aee2af302ed1340e59da3
-  React-Core-prebuilt: 09ce8e726c5136533196880286dea2a78bb86649
+  React-Core-prebuilt: 0e4660365d383fdf8e1a6efa76d4b5c4b7136c68
   React-CoreModules: 0b3b55b0b3954812ee0d67d85960bd7b42268336
   React-cxxreact: a76c6a3b36b20e777542946c20bebf67acbb631c
   React-debug: f9dda2791d3ebe2078bc6102641edab77917efb7
@@ -2220,10 +2218,10 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: ebcf3a78dc1bcdf054c9e8d309244bade6b31568
   ReactCodegen: c32ea010ee2565103b86c99f10f2861b0b1b97fe
   ReactCommon: e22f6e537e566de4c61121da2139a1980caff948
-  ReactNativeDependencies: 7287b718df1cac7f469898a828014ad21952769d
-  SdkReactNative: 7f000cecbec1a2d6324dc314b228e46b14ac7923
+  ReactNativeDependencies: cf54df6d13f5ce7007dacd6a14eefb7b9b78bb5a
+  SdkReactNative: 69a3870f1e71b52fb92379e9d7ca5bdffbe03fed
   Yoga: 90687fcd1ebd927341caed917696d692813c0b24
 
-PODFILE CHECKSUM: 858d70e8e5b2e838368aa0ddc1ce503ffd6050ba
+PODFILE CHECKSUM: 8a233d01a863787478346e8c9dba44afa0b99106
 
 COCOAPODS: 1.16.2

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -36,7 +36,7 @@ target 'SdkReactNativeExample' do
                       end
   didit_sdk_ios_path = ENV['DIDIT_SDK_IOS_PATH']
   if didit_sdk_ios_path.nil? || didit_sdk_ios_path.empty?
-    pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec'
+    pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec'
   else
     pod didit_sdk_subspec, :path => didit_sdk_ios_path
   end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,15 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - DiditSDK/All (4.0.2):
-    - DiditSDK/AutoDetection
-    - DiditSDK/NFC
-  - DiditSDK/AutoDetection (4.0.2):
-    - DiditSDK/Core
-    - MediaPipeTasksVision (= 0.10.21)
-  - DiditSDK/Core (4.0.2)
-  - DiditSDK/NFC (4.0.2):
-    - DiditSDK/Core
-    - NFCPassportReader (= 2.1.2)
+  - DiditSDK/All (4.3.1)
   - DoubleConversion (1.1.6)
   - fast_float (8.0.0)
   - FBLazyVector (0.83.0)
@@ -18,12 +9,6 @@ PODS:
   - hermes-engine (0.14.0):
     - hermes-engine/Pre-built (= 0.14.0)
   - hermes-engine/Pre-built (0.14.0)
-  - MediaPipeTasksCommon (0.10.21)
-  - MediaPipeTasksVision (0.10.21):
-    - MediaPipeTasksCommon (= 0.10.21)
-  - NFCPassportReader (2.1.2):
-    - OpenSSL-Universal (= 1.1.1900)
-  - OpenSSL-Universal (1.1.1900)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2465,9 +2450,9 @@ PODS:
     - React-perflogger (= 0.83.0)
     - React-utils (= 0.83.0)
     - SocketRocket
-  - SdkReactNative (4.0.1):
+  - SdkReactNative (4.3.1):
     - boost
-    - DiditSDK/All (~> 4.0)
+    - DiditSDK/All (= 4.3.1)
     - DoubleConversion
     - fast_float
     - fmt
@@ -2499,7 +2484,7 @@ PODS:
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
-  - DiditSDK/All (from `/Users/alexpinilla/Desktop/didit-repos/mobile-sdks/ios/sdk`)
+  - DiditSDK/All (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -2582,17 +2567,13 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - MediaPipeTasksCommon
-    - MediaPipeTasksVision
-    - NFCPassportReader
-    - OpenSSL-Universal
     - SocketRocket
 
 EXTERNAL SOURCES:
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   DiditSDK:
-    :path: "/Users/alexpinilla/Desktop/didit-repos/mobile-sdks/ios/sdk"
+    :podspec: https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.3.1/DiditSDK.podspec
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   fast_float:
@@ -2751,17 +2732,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  DiditSDK: d49a594d2fac35ff541c8450a631c9f3cc66eeca
+  DiditSDK: 915df5557629af1796d99cfb05ca6732d80b08b9
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a293a88992c4c33f0aee184acab0b64a08ff9458
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: ce33e8ac7c682a86889b51dc19f31508cd04efac
-  MediaPipeTasksCommon: 6cfa29170d4900f04d250ad95ec058f14a741f38
-  MediaPipeTasksVision: 7b1c0f5a5820e87e9d96926f5e65d8cd3744fac2
-  NFCPassportReader: 57c7824f4f5d620ce77eb8beb145a3469f0a7be5
-  OpenSSL-Universal: 84efb8a29841f2764ac5403e0c4119a28b713346
+  hermes-engine: 1c31e5fb417c6b43c8f6dfb6c299c79674b7fa27
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 2b70c6e3abe00396cefd8913efbf6a2db01a2b36
   RCTRequired: f3540eee8094231581d40c5c6d41b0f170237a81
@@ -2831,10 +2808,10 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: ebcf3a78dc1bcdf054c9e8d309244bade6b31568
   ReactCodegen: 11c08ff43a62009d48c71de000352e4515918801
   ReactCommon: 424cc34cf5055d69a3dcf02f3436481afb8b0f6f
-  SdkReactNative: 9224ea98968242188109b9d2fc86521157faf983
+  SdkReactNative: c0544c0595ad2a293a902f8b8a79cb8279ef793f
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 6ca93c8c13f56baeec55eb608577619b17a4d64e
 
-PODFILE CHECKSUM: 26e2128531748dbb56285cf22a1c828acd55026a
+PODFILE CHECKSUM: 0bcf3d76478a760b8a119e348848cf4561757add
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@didit-protocol/sdk-react-native",
   "version": "4.3.1",
+  "diditNativeSdkVersions": {
+    "ios": "4.3.1",
+    "android": "4.3.1"
+  },
   "description": "React Native wrapper for Didit Identity Verification SDK",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",

--- a/src/__tests__/native-sdk-pins.test.ts
+++ b/src/__tests__/native-sdk-pins.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The native Didit SDK version is pinned in several places that CocoaPods and
+ * Gradle read independently. When they drift apart, `pod install` fails for
+ * every consumer with "CocoaPods could not find compatible versions for pod
+ * DiditSDK/..." (issues #19 and #28), so every pin is asserted here against the
+ * single declared source of truth in package.json.
+ */
+
+const repoRoot = join(__dirname, '..', '..');
+
+const read = (relativePath: string) =>
+  readFileSync(join(repoRoot, relativePath), 'utf8');
+
+const pkg = JSON.parse(read('package.json'));
+const declaredIosVersion: string = pkg.diditNativeSdkVersions?.ios;
+const declaredAndroidVersion: string = pkg.diditNativeSdkVersions?.android;
+
+const PODSPEC_URL_PATTERN =
+  /raw\.githubusercontent\.com\/didit-protocol\/sdk-ios\/([^/'"\s]+)\/DiditSDK\.podspec/g;
+
+const podspecUrlRefs = (contents: string): string[] =>
+  Array.from(contents.matchAll(PODSPEC_URL_PATTERN), (match) =>
+    String(match[1])
+  );
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+const EXPO_PODFILE = [
+  "require 'json'",
+  "target 'App' do",
+  '  use_expo_modules!',
+  'end',
+].join('\n');
+
+const BARE_PODFILE = ["target 'App' do", '  use_native_modules!', 'end'].join(
+  '\n'
+);
+
+async function runPodfileMod(props: object, podfile: string) {
+  const withDiditSdk = require('../../app.plugin.js');
+  const config = withDiditSdk({ name: 'test', slug: 'test' }, props);
+  const result = await config.mods.ios.podfile({
+    ...config,
+    modResults: { contents: podfile },
+    modRequest: {
+      projectRoot: repoRoot,
+      platformProjectRoot: repoRoot,
+      modName: 'podfile',
+      platform: 'ios',
+      introspect: true,
+    },
+  });
+  return result.modResults.contents as string;
+}
+
+describe('declared native SDK versions', () => {
+  it('declares an iOS and an Android native SDK version in package.json', () => {
+    expect(declaredIosVersion).toMatch(SEMVER);
+    expect(declaredAndroidVersion).toMatch(SEMVER);
+  });
+});
+
+describe('expo config plugin podspec pin', () => {
+  it('injects the declared iOS version into an Expo Podfile', async () => {
+    const contents = await runPodfileMod({}, EXPO_PODFILE);
+
+    expect(podspecUrlRefs(contents)).toEqual([declaredIosVersion]);
+  });
+
+  it('injects the declared iOS version into a bare React Native Podfile', async () => {
+    const contents = await runPodfileMod({}, BARE_PODFILE);
+
+    expect(podspecUrlRefs(contents)).toEqual([declaredIosVersion]);
+  });
+
+  it('lets a consumer override the podspec URL as an escape hatch', async () => {
+    const iosPodspecUrl = 'https://example.com/custom/DiditSDK.podspec';
+
+    const contents = await runPodfileMod({ iosPodspecUrl }, EXPO_PODFILE);
+
+    expect(contents).toContain(`:podspec => '${iosPodspecUrl}'`);
+  });
+
+  it('does not hardcode a version literal in the plugin source', () => {
+    const hardcoded = podspecUrlRefs(read('app.plugin.js')).filter((version) =>
+      SEMVER.test(version)
+    );
+
+    expect(hardcoded).toEqual([]);
+  });
+});
+
+describe('SdkReactNative.podspec dependency pin', () => {
+  const podspec = read('SdkReactNative.podspec');
+
+  it('derives the DiditSDK dependency version from package.json', () => {
+    expect(podspec).toMatch(
+      /s\.dependency\s+didit_sdk_subspec\s*,\s*didit_sdk_ios_version/
+    );
+  });
+
+  it('does not hardcode a version literal for the DiditSDK dependency', () => {
+    expect(podspec).not.toMatch(
+      /s\.dependency\s+didit_sdk_subspec\s*,\s*["']\d+\.\d+\.\d+["']/
+    );
+  });
+});
+
+describe('hand-maintained pins stay in lockstep', () => {
+  it.each(['README.md', 'example/ios/Podfile', 'example-expo/ios/Podfile'])(
+    '%s references only the declared iOS version',
+    (relativePath) => {
+      const refs = podspecUrlRefs(read(relativePath));
+
+      expect(refs.length).toBeGreaterThan(0);
+      refs.forEach((version) => expect(version).toBe(declaredIosVersion));
+    }
+  );
+
+  it('android/build.gradle pins the declared Android version', () => {
+    const match = read('android/build.gradle').match(
+      /me\.didit:\$diditSdkAndroidArtifact:([\d.]+)/
+    );
+
+    expect(match?.[1]).toBe(declaredAndroidVersion);
+  });
+});

--- a/src/__tests__/native-sdk-pins.test.ts
+++ b/src/__tests__/native-sdk-pins.test.ts
@@ -84,6 +84,15 @@ describe('expo config plugin podspec pin', () => {
     expect(contents).toContain(`:podspec => '${iosPodspecUrl}'`);
   });
 
+  it('rejects an override that would break the generated Podfile', async () => {
+    await expect(
+      runPodfileMod(
+        { iosPodspecUrl: "https://example.com/'.podspec" },
+        EXPO_PODFILE
+      )
+    ).rejects.toThrow(/iosPodspecUrl/);
+  });
+
   it('does not hardcode a version literal in the plugin source', () => {
     const hardcoded = podspecUrlRefs(read('app.plugin.js')).filter((version) =>
       SEMVER.test(version)


### PR DESCRIPTION
Fixes #28 (regression of #19).

## Root cause

`app.plugin.js` pinned the sdk-ios podspec URL to `4.1.0` in a module-level constant, while `SdkReactNative.podspec` depended on `DiditSDK` at a hardcoded `4.3.1`. CocoaPods therefore saw two incompatible requirements for the same pod and could not resolve, breaking `pod install` for every consumer on 4.2.0+.

Reproduced locally in `example-expo/ios` before the fix:

```
[!] CocoaPods could not find compatible versions for pod "DiditSDK/All":
  In Podfile:
    DiditSDK/All (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.1.0/DiditSDK.podspec`)

    SdkReactNative (from `../..`) was resolved to 4.3.1, which depends on
      DiditSDK/All (= 4.3.1)
```

## Fix

Both values now derive from a single declared source of truth in `package.json`:

```json
"diditNativeSdkVersions": { "ios": "4.3.1", "android": "4.3.1" }
```

The issue suggested deriving from `package.version`. That would break on the very next release: this fix ships as a wrapper-only bump, and `sdk-ios` has no matching tag for it, so the URL would 404. The wrapper and native versions are genuinely independent, so the native pin is declared explicitly.

- `app.plugin.js` builds the URL from `diditNativeSdkVersions.ios`, and accepts an `iosPodspecUrl` prop as an escape hatch (fork, mirror, prerelease tag)
- `SdkReactNative.podspec` reads the `DiditSDK` dependency version from the same field
- `example/ios/Podfile` (floating `main`) and `example-expo/ios/Podfile` (stale `4.1.0`) are pinned to the declared version; both lockfiles regenerated - the bare example's lock had been committed with a contributor's local `:path` and DiditSDK 4.0.2
- `src/__tests__/native-sdk-pins.test.ts` runs the plugin's real Podfile mod and asserts the emitted URL, plus every hand-maintained pin (README, both example Podfiles, `android/build.gradle`), so CI fails on the next drift instead of consumers
- CONTRIBUTING documents the bump procedure

## Verification

- `yarn test` - 15 passed (the new suite fails with 10 errors against the pre-fix code)
- `yarn lint`, `yarn typecheck` - clean
- `pod install` in `example-expo/ios`: succeeds, resolves `DiditSDK/All (4.3.1)` against `SdkReactNative (4.3.1)`
- `pod install` in `example/ios`: succeeds, same resolution
- Real `npx expo prebuild --platform ios` in a scratch app emits `.../sdk-ios/4.3.1/DiditSDK.podspec`

## Deploy

npm publish only - no backend or native SDK deploy. This must ship as a new npm release (e.g. 4.3.2) for affected consumers; until then the workarounds in the issue stand. `diditNativeSdkVersions` stays at 4.3.1, so the published podspec URL keeps pointing at the existing sdk-ios 4.3.1 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)