### PR TITLE
fix(android): single-source the native SDK pin from package.json

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,13 @@ def diditSdkAndroidVariant = (
     ? diditSdkAndroidVariantProperty
     : (diditSdkAndroidLegacyNfcEnabled ? "all" : "core")
 ).toString().toLowerCase()
+def diditSdkAndroidVersion = new groovy.json.JsonSlurper()
+  .parseText(file("$projectDir/../package.json").text)
+  .diditNativeSdkVersions
+  .android
+if (diditSdkAndroidVersion == null || diditSdkAndroidVersion.toString().isEmpty()) {
+  throw new GradleException("diditNativeSdkVersions.android missing from package.json")
+}
 def diditSdkAndroidArtifact
 switch (diditSdkAndroidVariant) {
   case "all":
@@ -123,7 +130,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
 
   // Didit native Android SDK
-  implementation "me.didit:$diditSdkAndroidArtifact:4.3.1"
+  implementation "me.didit:$diditSdkAndroidArtifact:$diditSdkAndroidVersion"
 
   // Coroutines (required for state flow observation)
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"


### PR DESCRIPTION
## What

`android/build.gradle` hardcoded the native Android SDK version (`me.didit:...:4.3.1`) while the iOS podspec already read it from `package.json` → `diditNativeSdkVersions.ios`. Gradle now reads `diditNativeSdkVersions.android` from the same place, and fails loudly if the key is missing.

**The resolved value is unchanged at `4.3.1`** — this is purely removing a drift source, not a version change.

## Why

That asymmetry is exactly the class of bug that let the iOS SDK version reach `4.1.0` in `EventService` while the podspec shipped `4.3.1` (fixed separately in mobile-sdks#41). A hardcoded pin in one platform and a single-sourced pin in the other guarantees they eventually disagree.

## Verification

The `JsonSlurper` expression was evaluated in a real Gradle runtime and resolves correctly:

```
RESOLVED_ANDROID_PIN=4.3.1
```

Note: `./gradlew` in `example/android` currently fails locally with `Failed to apply plugin 'com.facebook.react.rootproject'` — I confirmed this failure is **identical with and without this change**, so it is a pre-existing local toolchain issue, not a regression from this PR. CI should be the authority here.

## Not included

The native pin is **not** bumped to `4.4.0` here. Native 4.4.0 (device-integrity signals, mobile-sdks#41) is not yet tagged on `sdk-ios` or published to Maven — pinning it now would break resolution. That bump belongs in a follow-up once 4.4.0 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)