### PR TITLE
fix: apply Bouncy Castle exclusions to autodetection

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -228,7 +228,7 @@ const DIDIT_ANDROID_BLOCK = `
     }`;
 
 function withDiditPackagingExclusion(config, androidVariant) {
-  if (!['all', 'nfc'].includes(androidVariant)) {
+  if (!['all', 'autodetection', 'nfc'].includes(androidVariant)) {
     return config;
   }
 

--- a/src/__tests__/native-sdk-pins.test.ts
+++ b/src/__tests__/native-sdk-pins.test.ts
@@ -39,6 +39,37 @@ const BARE_PODFILE = ["target 'App' do", '  use_native_modules!', 'end'].join(
   '\n'
 );
 
+const APP_BUILD_GRADLE = [
+  "plugins { id 'com.android.application' }",
+  '',
+  'android {',
+  "    namespace 'com.example'",
+  '}',
+].join('\n');
+
+async function runAppBuildGradleMod(props: object, appBuildGradle: string) {
+  const withDiditSdk = require('../../app.plugin.js');
+  const config = withDiditSdk({ name: 'test', slug: 'test' }, props);
+  const appBuildGradleMod = config.mods.android.appBuildGradle;
+
+  if (!appBuildGradleMod) {
+    return appBuildGradle;
+  }
+
+  const result = await appBuildGradleMod({
+    ...config,
+    modResults: { contents: appBuildGradle, language: 'groovy' },
+    modRequest: {
+      projectRoot: repoRoot,
+      platformProjectRoot: repoRoot,
+      modName: 'appBuildGradle',
+      platform: 'android',
+      introspect: true,
+    },
+  });
+  return result.modResults.contents as string;
+}
+
 async function runPodfileMod(props: object, podfile: string) {
   const withDiditSdk = require('../../app.plugin.js');
   const config = withDiditSdk({ name: 'test', slug: 'test' }, props);
@@ -99,6 +130,43 @@ describe('expo config plugin podspec pin', () => {
     );
 
     expect(hardcoded).toEqual([]);
+  });
+});
+
+describe('expo config plugin Android packaging exclusions', () => {
+  it.each(['all', 'autodetection', 'nfc'])(
+    'injects Bouncy Castle exclusions for the %s variant',
+    async (androidVariant) => {
+      const contents = await runAppBuildGradleMod(
+        { androidVariant },
+        APP_BUILD_GRADLE
+      );
+
+      expect(contents).toContain("exclude group: 'org.bouncycastle'");
+      expect(contents).toContain("module: 'bcprov-jdk15to18'");
+    }
+  );
+
+  it('does not add exclusions to the core variant', async () => {
+    const contents = await runAppBuildGradleMod(
+      { androidVariant: 'core' },
+      APP_BUILD_GRADLE
+    );
+
+    expect(contents).toBe(APP_BUILD_GRADLE);
+  });
+
+  it('is idempotent across repeated prebuilds', async () => {
+    const once = await runAppBuildGradleMod(
+      { androidVariant: 'autodetection' },
+      APP_BUILD_GRADLE
+    );
+    const twice = await runAppBuildGradleMod(
+      { androidVariant: 'autodetection' },
+      once
+    );
+
+    expect(twice).toBe(once);
   });
 });
 


### PR DESCRIPTION
## Summary

- apply the existing Android Bouncy Castle exclusion block when the Didit Expo plugin uses the `autodetection` variant
- add config-plugin regression coverage for `all`, `autodetection`, and `nfc`
- verify the `core` variant remains unchanged and repeated prebuilds remain idempotent

Fixes #34.

## Root cause

`withDiditPackagingExclusion` already contains the exclusions required to prevent overlapping `jdk15to18`, `jdk15on`, and Didit's `jdk18on` Bouncy Castle dependencies. However, the function returned early for `autodetection`, even though that artifact depends on `didit-sdk-core` and can bring in the `jdk18on` path through Reown/Web3j.

In Expo apps that also use `expo-updates`, the generated Android project could therefore resolve both Bouncy Castle families and fail release builds with duplicate classes.

## Validation

- `yarn test native-sdk-pins.test.ts --runInBand`
- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand`
- `yarn prepare`

All checks pass locally. The full Jest suite reports 26 passing tests.
