### PR TITLE
fix(expo-plugin): apply Bouncy Castle exclusions for the autodetection Android variant

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -227,8 +227,17 @@ const DIDIT_ANDROID_BLOCK = `
         }
     }`;
 
+/**
+ * These variants pull Bouncy Castle jdk18on transitively (didit-sdk-core via
+ * Reown/Web3j, didit-sdk-nfc via jmrtd), which collides with the jdk15to18
+ * family that host apps commonly bring in through expo-updates. `autodetection`
+ * was missing from this list, so its release builds failed with duplicate
+ * classes (issue #34).
+ */
+const BOUNCY_CASTLE_VARIANTS = ['all', 'autodetection', 'nfc'];
+
 function withDiditPackagingExclusion(config, androidVariant) {
-  if (!['all', 'nfc'].includes(androidVariant)) {
+  if (!BOUNCY_CASTLE_VARIANTS.includes(androidVariant)) {
     return config;
   }
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -228,19 +228,25 @@ const DIDIT_ANDROID_BLOCK = `
     }`;
 
 /**
- * These variants pull Bouncy Castle jdk18on transitively (didit-sdk-core via
- * Reown/Web3j, didit-sdk-nfc via jmrtd), which collides with the jdk15to18
- * family that host apps commonly bring in through expo-updates. `autodetection`
- * was missing from this list, so its release builds failed with duplicate
- * classes (issue #34).
+ * Applies to EVERY Android variant, because every variant ships
+ * `didit-sdk-core`, and `didit-sdk-core` alone already pulls Bouncy Castle
+ * jdk18on through two independent chains:
+ *
+ *   didit-sdk-core -> com.reown:android-core -> com.reown:foundation
+ *                       -> org.bouncycastle:bcprov-jdk18on
+ *   didit-sdk-core -> com.reown:android-core -> org.web3j:crypto
+ *                       -> org.web3j:utils -> org.bouncycastle:bcprov-jdk18on
+ *
+ * (`didit-sdk-nfc` adds two more via a direct declaration and jmrtd.)
+ * That collides with the jdk15to18 family host apps commonly bring in through
+ * expo-updates, so release builds fail with duplicate classes. The variant
+ * allowlist this replaces covered only `all` and `nfc`, which broke
+ * `autodetection` (issue #34) and left `core` exposed to the same failure.
+ *
+ * Verified by resolving `me.didit:didit-sdk-core:4.5.3` on its own with Gradle:
+ * 291 modules resolved, including org.bouncycastle:bcprov-jdk18on:1.78.1.
  */
-const BOUNCY_CASTLE_VARIANTS = ['all', 'autodetection', 'nfc'];
-
-function withDiditPackagingExclusion(config, androidVariant) {
-  if (!BOUNCY_CASTLE_VARIANTS.includes(androidVariant)) {
-    return config;
-  }
-
+function withDiditPackagingExclusion(config) {
   return withAppBuildGradle(config, (mod) => {
     if (mod.modResults.contents.includes('bcprov-jdk15to18')) {
       return mod;
@@ -278,7 +284,7 @@ function withDiditAndroidMaven(config, options) {
   config = withDiditBuildGradle(config);
   config = withDiditSettingsGradle(config);
   config = withDiditAndroidVariantProperty(config, options.androidVariant);
-  config = withDiditPackagingExclusion(config, options.androidVariant);
+  config = withDiditPackagingExclusion(config);
   return config;
 }
 

--- a/src/__tests__/android-packaging-exclusion.test.ts
+++ b/src/__tests__/android-packaging-exclusion.test.ts
@@ -1,0 +1,106 @@
+import { join } from 'path';
+
+/**
+ * The DiditSDK Android variants that bundle didit-sdk-core (all, autodetection,
+ * nfc) pull Bouncy Castle jdk18on through Reown/Web3j, while host apps commonly
+ * pull the jdk15to18 family (e.g. via expo-updates). Without the plugin's
+ * exclusion block in app/build.gradle the release build fails with duplicate
+ * classes. Issue #34: the block was skipped for `autodetection`.
+ */
+
+const repoRoot = join(__dirname, '..', '..');
+
+const MINIMAL_APP_BUILD_GRADLE = [
+  'apply plugin: "com.android.application"',
+  '',
+  'android {',
+  "    namespace 'com.example.app'",
+  '    defaultConfig {',
+  '        applicationId "com.example.app"',
+  '    }',
+  '}',
+  '',
+  'dependencies {',
+  '    implementation("com.facebook.react:react-android")',
+  '}',
+].join('\n');
+
+const EXCLUDED_MODULES = [
+  'bcprov-jdk15to18',
+  'bcutil-jdk15to18',
+  'bcpkix-jdk15to18',
+  'bcprov-jdk15on',
+];
+
+async function runAppBuildGradleMod(props: object, contents: string) {
+  const withDiditSdk = require('../../app.plugin.js');
+  const config = withDiditSdk({ name: 'test', slug: 'test' }, props);
+  // Variants without the exclusion register no appBuildGradle mod at all,
+  // which is equivalent to leaving the file untouched.
+  if (!config.mods?.android?.appBuildGradle) {
+    return contents;
+  }
+  const result = await config.mods.android.appBuildGradle({
+    ...config,
+    modResults: { contents, language: 'groovy', path: '' },
+    modRequest: {
+      projectRoot: repoRoot,
+      platformProjectRoot: repoRoot,
+      modName: 'appBuildGradle',
+      platform: 'android',
+      introspect: true,
+    },
+  });
+  return result.modResults.contents as string;
+}
+
+const expectExclusionBlock = (contents: string) => {
+  EXCLUDED_MODULES.forEach((module) => {
+    expect(contents).toContain(
+      `exclude group: 'org.bouncycastle', module: '${module}'`
+    );
+  });
+  expect(contents).toContain("pickFirsts += ['org/bouncycastle/**']");
+};
+
+describe('Bouncy Castle packaging exclusion (app/build.gradle)', () => {
+  it.each(['all', 'autodetection', 'nfc'])(
+    'injects the exclusion block for the %s variant',
+    async (androidVariant) => {
+      const contents = await runAppBuildGradleMod(
+        { androidVariant },
+        MINIMAL_APP_BUILD_GRADLE
+      );
+
+      expectExclusionBlock(contents);
+    }
+  );
+
+  it('injects the exclusion block when no variant is configured (legacy default: all)', async () => {
+    const contents = await runAppBuildGradleMod({}, MINIMAL_APP_BUILD_GRADLE);
+
+    expectExclusionBlock(contents);
+  });
+
+  it('leaves the core variant untouched', async () => {
+    const contents = await runAppBuildGradleMod(
+      { androidVariant: 'core' },
+      MINIMAL_APP_BUILD_GRADLE
+    );
+
+    expect(contents).toBe(MINIMAL_APP_BUILD_GRADLE);
+  });
+
+  it('stays idempotent across repeated prebuilds', async () => {
+    const once = await runAppBuildGradleMod(
+      { androidVariant: 'autodetection' },
+      MINIMAL_APP_BUILD_GRADLE
+    );
+    const twice = await runAppBuildGradleMod(
+      { androidVariant: 'autodetection' },
+      once
+    );
+
+    expect(twice).toBe(once);
+  });
+});

--- a/src/__tests__/android-packaging-exclusion.test.ts
+++ b/src/__tests__/android-packaging-exclusion.test.ts
@@ -1,11 +1,14 @@
 import { join } from 'path';
 
 /**
- * The DiditSDK Android variants that bundle didit-sdk-core (all, autodetection,
- * nfc) pull Bouncy Castle jdk18on through Reown/Web3j, while host apps commonly
- * pull the jdk15to18 family (e.g. via expo-updates). Without the plugin's
- * exclusion block in app/build.gradle the release build fails with duplicate
- * classes. Issue #34: the block was skipped for `autodetection`.
+ * EVERY DiditSDK Android variant ships didit-sdk-core, and didit-sdk-core pulls
+ * Bouncy Castle jdk18on transitively (via reown/foundation and via
+ * web3j/utils), while host apps commonly pull the jdk15to18 family (e.g. via
+ * expo-updates). Without the plugin's exclusion block in app/build.gradle the
+ * release build fails with duplicate classes.
+ *
+ * Issue #34 reported the block being skipped for `autodetection`; `core` was
+ * skipped for the same reason and is covered here too.
  */
 
 const repoRoot = join(__dirname, '..', '..');
@@ -64,7 +67,7 @@ const expectExclusionBlock = (contents: string) => {
 };
 
 describe('Bouncy Castle packaging exclusion (app/build.gradle)', () => {
-  it.each(['all', 'autodetection', 'nfc'])(
+  it.each(['all', 'core', 'autodetection', 'nfc'])(
     'injects the exclusion block for the %s variant',
     async (androidVariant) => {
       const contents = await runAppBuildGradleMod(
@@ -82,13 +85,16 @@ describe('Bouncy Castle packaging exclusion (app/build.gradle)', () => {
     expectExclusionBlock(contents);
   });
 
-  it('leaves the core variant untouched', async () => {
+  // No variant may skip the exclusion, so an unrecognized value must not become
+  // an accidental opt-out either -- normalizeVariant folds it back to a
+  // supported variant, which still ships didit-sdk-core.
+  it('injects the exclusion block for an unrecognized variant', async () => {
     const contents = await runAppBuildGradleMod(
-      { androidVariant: 'core' },
+      { androidVariant: 'not-a-real-variant' },
       MINIMAL_APP_BUILD_GRADLE
     );
 
-    expect(contents).toBe(MINIMAL_APP_BUILD_GRADLE);
+    expectExclusionBlock(contents);
   });
 
   it('stays idempotent across repeated prebuilds', async () => {


### PR DESCRIPTION
## What

`withDiditPackagingExclusion` in `app.plugin.js` gated its Bouncy Castle exclusion block behind a variant allowlist that contained only `all` and `nfc`, so the block was never injected into `android/app/build.gradle` for other variants.

This PR removes the allowlist entirely and always injects the existing `DIDIT_ANDROID_BLOCK` (dependency exclusions + packaging `pickFirsts`).

Fixes #34.

## Why the allowlist is dropped rather than extended

The issue reported `autodetection`. While verifying it, `core` turned out to be broken the same way, so extending the list to three values would have left the fourth variant failing.

Every Android variant ships `didit-sdk-core`, and `didit-sdk-core` **on its own** already pulls Bouncy Castle jdk18on through two independent chains:

```
didit-sdk-core -> com.reown:android-core:1.4.1 -> com.reown:foundation:1.4.1
                    -> org.bouncycastle:bcprov-jdk18on:1.78.1
didit-sdk-core -> com.reown:android-core:1.4.1 -> org.web3j:crypto:4.9.8-hotfix
                    -> org.web3j:utils:4.9.8-hotfix -> org.bouncycastle:bcprov-jdk18on:1.77
```

(`didit-sdk-nfc` adds two more: a direct declaration and `org.jmrtd:jmrtd`.)

That collides with the `jdk15to18` family host apps commonly bring in through `expo-updates`, which is the duplicate-class failure in #34.

Worth noting because it is easy to check one hop too few: `org.web3j:crypto` declares no Bouncy Castle itself. The declaration is one level deeper, in `org.web3j:utils`.

### Verification

Resolved `me.didit:didit-sdk-core:4.5.3` on its own with Gradle 9 (no Android plugin, metadata only):

```
===== probeCore =====
  total modules resolved: 291
  BC: org.bouncycastle:bcprov-jdk18on:1.78.1
      <- com.reown:foundation:1.4.1
      <- org.web3j:utils:4.9.8-hotfix
```

So `core` sits on the exact same conflict path as the variants the plugin already guarded.

## Tests

Regression suite `src/__tests__/android-packaging-exclusion.test.ts` drives the plugin's real `appBuildGradle` mod (same pattern as the existing Podfile tests) against a minimal `app/build.gradle` fixture:

- injects the exclusion block for `all`, `core`, `autodetection` and `nfc`
- injects for the legacy default (no props)
- injects for an unrecognized variant, so a typo cannot become a silent opt-out
- stays idempotent across repeated prebuilds (second application is a no-op)

Red/green check: with the allowlist restored to `['all', 'autodetection', 'nfc']`, the `core` case fails and the other six pass. With this change, 28/28 tests pass; lint and typecheck clean.

The previous revision of this PR contained a `leaves the core variant untouched` test. That assertion pinned the bug in place, so it is replaced by the unrecognized-variant case above.

## Risk

Low, and it does not regress anyone who builds today. The block only excludes `jdk15to18`/`jdk15on` modules; excluding a module the graph does not contain is a no-op, so a `core` app that currently builds keeps building, and a `core` app that would have hit the duplicate-class failure now resolves the same way `all` and `nfc` already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
