### PR TITLE
release 4.5.4 - iOS dSYM artifacts, Expo Bouncy Castle fix for all variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The iOS podspec URL is derived from the native SDK version this package pins (`d
 [
   "@didit-protocol/sdk-react-native",
   {
-    "iosPodspecUrl": "https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.3/DiditSDK.podspec"
+    "iosPodspecUrl": "https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.4/DiditSDK.podspec"
   }
 ]
 ```
@@ -200,7 +200,7 @@ didit_sdk_subspec = case $DiditSdkIosVariant
                     else
                       raise "Invalid $DiditSdkIosVariant '#{$DiditSdkIosVariant}'. Supported values: all, core, autodetection, nfc."
                     end
-pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.3/DiditSDK.podspec'
+pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.4/DiditSDK.podspec'
 ```
 
 ##### Swift Package Manager (optional)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -123,7 +123,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
 
   // Didit native Android SDK
-  implementation "me.didit:$diditSdkAndroidArtifact:4.5.3"
+  implementation "me.didit:$diditSdkAndroidArtifact:4.5.4"
 
   // Coroutines (required for state flow observation)
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"

--- a/example-expo/ios/Podfile
+++ b/example-expo/ios/Podfile
@@ -30,7 +30,7 @@ target 'DiditExpoExample' do
                       else
                         raise "Invalid $DiditSdkIosVariant '#{$DiditSdkIosVariant}'. Supported values: all, core, autodetection, nfc."
                       end
-  pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.3/DiditSDK.podspec'
+  pod didit_sdk_subspec, :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.4/DiditSDK.podspec'
 
   use_expo_modules!
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@didit-protocol/sdk-react-native",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "diditNativeSdkVersions": {
-    "ios": "4.5.3",
-    "android": "4.5.3"
+    "ios": "4.5.4",
+    "android": "4.5.4"
   },
   "description": "React Native wrapper for Didit Identity Verification SDK",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Release 4.5.4

Bumps the package to 4.5.4 and both native pins to 4.5.4.

| File | Change |
|---|---|
| `package.json` | `version`, `diditNativeSdkVersions.ios`, `diditNativeSdkVersions.android` → 4.5.4 |
| `android/build.gradle` | `me.didit:$diditSdkAndroidArtifact` → 4.5.4 |
| `README.md` | podspec URL → `sdk-ios/4.5.4` |
| `example-expo/ios/Podfile` | podspec URL → `sdk-ios/4.5.4` |

The last two were caught by `native-sdk-pins.test.ts` rather than by hand, which is exactly what that suite is for.

## What ships

- **Expo plugin fix (#34)** — the Bouncy Castle exclusion block is now applied for every Android variant. `autodetection` was reported broken; `core` was silently affected by the same duplicate-class failure.
- **iOS dSYM artifacts** — 4.5.4 publishes `dSYM.zip` assets so crashes inside `DiditSDK.framework` can be symbolicated (didit-protocol/sdk-ios#4). Shipped binaries unchanged.
- **Android 4.5.4** — lockstep rebuild, no source changes.

## Verification

Both native versions are already published and live, so these pins do not point at anything that does not exist:

- `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.5.4/DiditSDK.podspec` → HTTP 200, serves `s.version = '4.5.4'`
- `.../sdk-android/main/repository/me/didit/didit-sdk-core/4.5.4/didit-sdk-core-4.5.4.aar` → HTTP 200
- iOS SPM resolution of `exact: "4.5.4"` verified end-to-end: all five binary targets downloaded and checksum-validated

28/28 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)